### PR TITLE
add union parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/wip.kai
 kai_tests*
 scripts/clang-with-compilation-db
 compile_commands.json
+DerivedData

--- a/kai.xcodeproj/project.pbxproj
+++ b/kai.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = c11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = (
 					"-DTEST",
 					"-DNO_COLOR",
@@ -240,6 +241,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = c11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = (
 					"-DTEST",
 					"-DNO_COLOR",
@@ -362,6 +364,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = c11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = (
 					"-g",
 					"-O0",
@@ -383,6 +386,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = c11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = (
 					"-O3",
 					"-march=native",

--- a/src/ast.c
+++ b/src/ast.c
@@ -727,7 +727,11 @@ Expr *NewExprTypeEnum(Package *package, Position start, Expr *explicitType, Dyna
     return e;
 }
 
-Expr *NewExprTypeUnion(Package *package);
+Expr *NewExprTypeUnion(Package *package, Position start, DynamicArray(AggregateItem) items)  {
+    Expr *e = NewExpr(package, ExprKind_TypeUnion, start);
+    e->TypeUnion.items = items;
+    return e;
+}
 
 Expr *NewExprTypePolymorphic(Package *package, Position start, const char *name) {
     Expr *e = NewExpr(package, ExprKind_TypePolymorphic, start);

--- a/src/parser.c
+++ b/src/parser.c
@@ -265,6 +265,7 @@ Expr *parseExprAtom(Parser *p) {
             // TODO(Brett, vdka): directives
 
             if (isToken(p, TK_Lparen)) {
+                // TODO(Brett, vdka): polymorphic structs
                 UNIMPLEMENTED();
             }
 
@@ -301,11 +302,6 @@ Expr *parseExprAtom(Parser *p) {
             nextToken();
 
             // TODO(Brett, vdka): directives
-
-            if (isToken(p, TK_Lparen)) {
-                // TODO(Brett, vdka): polymorphic structs
-                UNIMPLEMENTED();
-            }
 
             expectToken(p, TK_Lbrace);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -265,7 +265,6 @@ Expr *parseExprAtom(Parser *p) {
             // TODO(Brett, vdka): directives
 
             if (isToken(p, TK_Lparen)) {
-                // TODO(Brett, vdka): polymorphic structs
                 UNIMPLEMENTED();
             }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -298,8 +298,42 @@ Expr *parseExprAtom(Parser *p) {
         }
 
         caseUnion: {
-            UNIMPLEMENTED();
-            break;
+            Position start = p->tok.pos;
+            nextToken();
+
+            // TODO(Brett, vdka): directives
+
+            if (isToken(p, TK_Lparen)) {
+                // TODO(Brett, vdka): polymorphic structs
+                UNIMPLEMENTED();
+            }
+
+            expectToken(p, TK_Lbrace);
+
+            DynamicArray(AggregateItem) items = NULL;
+
+            while (!isToken(p, TK_Rbrace)) {
+                Position start = p->tok.pos;
+
+                DynamicArray(const char *) names = parseIdentList(p);
+
+                expectToken(p, TK_Colon);
+
+                Expr *type = parseType(p);
+
+                AggregateItem item = {.start = start, .names = names, .type = type};
+                ArrayPush(items, item);
+
+                if (isToken(p, TK_Rbrace)) {
+                    break;
+                }
+
+                expectTerminator(p);
+            }
+
+            expectToken(p, TK_Rbrace);
+
+            return NewExprTypeUnion(pkg, start, items);
         }
 
         caseEnum: {
@@ -1089,5 +1123,24 @@ void test_parseStruct() {
 
     p = newTestParser("struct { a, b, c: u32 }");
     ASSERT_EXPR_KIND(ExprKind_TypeStruct);
+}
+#endif
+
+#if TEST
+void test_parseUnion() {
+#define ASSERT_EXPR_KIND(expected) \
+expr = parseExprAtom(&p); \
+ASSERT(expr->kind == expected); \
+ASSERT(!testPackage.diagnostics.errors)
+
+    Expr *expr;
+    Parser p;
+
+    /*
+     *  A mini-test-suite for unions
+     */
+
+    p = newTestParser("union { a, b, c: u32 }");
+    ASSERT_EXPR_KIND(ExprKind_TypeUnion);
 }
 #endif


### PR DESCRIPTION
Implements `union` parsing and adds a test. Also some gardening: lower the macOS deployment target to sierra and gitignore local Xcode derived data.