### PR TITLE
Remove untyped types and expand the type coercion tests

### DIFF
--- a/src/checker.h
+++ b/src/checker.h
@@ -7,6 +7,20 @@ typedef enum CheckerInfoKind {
     CheckerInfoKind_BasicExpr,
 } CheckerInfoKind;
 
+typedef u8 Conversion;
+#define ConversionClass_Mask 0x07  // Lower 3 bits denote the class
+#define ConversionClass_None 0
+#define ConversionClass_Same 1
+#define ConversionClass_FtoI 2
+#define ConversionClass_ItoF 3
+#define ConversionClass_PtoI 4
+#define ConversionClass_ItoP 5
+#define ConversionClass_Bool 6
+#define ConversionClass_Any  7
+
+#define ConversionFlag_Extend 0x10 // 0001
+#define ConversionFlag_Signed 0x20 // 0010
+
 typedef struct CheckerInfo_Constant CheckerInfo_Constant;
 struct CheckerInfo_Constant {
     Symbol *symbol;
@@ -19,26 +33,34 @@ struct CheckerInfo_Variable {
 
 typedef struct CheckerInfo_Ident CheckerInfo_Ident;
 struct CheckerInfo_Ident {
+    Conversion coerce;
     Symbol *symbol;
 };
 
 typedef struct CheckerInfo_Selector CheckerInfo_Selector;
 struct CheckerInfo_Selector {
+    Conversion coerce;
     u32 levelsOfIndirection;
     Val constant;
 };
 
 typedef struct CheckerInfo_BasicExpr CheckerInfo_BasicExpr;
 struct CheckerInfo_BasicExpr {
+    Conversion coerce;
     Type *type;
     b8 isConstant;
     Val val;
 };
 
+STATIC_ASSERT(offsetof(CheckerInfo_Ident,     coerce) == 0, "conversion must be at offset 0 for expressions");
+STATIC_ASSERT(offsetof(CheckerInfo_Selector,  coerce) == 0, "conversion must be at offset 0 for expressions");
+STATIC_ASSERT(offsetof(CheckerInfo_BasicExpr, coerce) == 0, "conversion must be at offset 0 for expressions");
+
 typedef struct CheckerInfo CheckerInfo;
 struct CheckerInfo {
     CheckerInfoKind kind;
     union {
+        Conversion coerce; // Present when CheckerInfo is for an expression
         CheckerInfo_Constant Constant;
         CheckerInfo_Variable Variable;
         CheckerInfo_Selector Selector;

--- a/src/common.c
+++ b/src/common.c
@@ -225,6 +225,17 @@ void PrintBits(u64 const size, void const * const ptr) {
     puts("");
 }
 
+u64 IntegerPower(u64 base, u64 exp) {
+    u64 result = 1;
+    for (;;) {
+        if (exp & 1) result *= base;
+        exp >>= 1;
+        if (!exp) break;
+        base *= base;
+    }
+    return result;
+}
+
 #if TEST
 void test_GetFileName() {
     char buff[MAX_PATH];

--- a/src/constant_eval.c
+++ b/src/constant_eval.c
@@ -48,9 +48,9 @@ b32 evalBinary(TokenKind op, Type *type, Val lhsValue, Val rhsValue, ExprInfo *i
         isConstant = false;
     }
     info->isConstant = isConstant;
+
     return isConstant;
 }
-
 
 i64 evalUnarySigned(TokenKind op, Val val) {
     switch (op) {

--- a/src/error.c
+++ b/src/error.c
@@ -33,7 +33,8 @@
     FOR_EACH(InvalidBinaryOperation, "Binary operation invalid for type") \
     FOR_EACH(DivisionByZero, "Divided by zero") \
     FOR_EACH(TypeMismatch, "Type did not match") \
-    FOR_EACH(BadCondition, "Expected a numeric or pointer type to act as a condition")
+    FOR_EACH(BadCondition, "Expected a numeric or pointer type to act as a condition") \
+    FOR_EACH(UnrepresentableValue, "The value could not be represented in the desired type without loss of information")
 
 typedef enum ErrorCode {
 #define FOR_EACH(e, s) e##Error,

--- a/src/llvm.cpp
+++ b/src/llvm.cpp
@@ -39,6 +39,9 @@
 
 #pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch"
+
 typedef struct DebugTypes {
     llvm::DIType *i8;
     llvm::DIType *i16;
@@ -129,15 +132,9 @@ llvm::DIType *debugCanonicalize(LLVMGen *gen, Type *type) {
         }
     }
 
-    if (type == UntypedIntType)
-        return types.i64;
-
     if (type->kind == TypeKind_Float) {
         return type->Width == 32 ? types.f32 : types.f64;
     }
-
-    if (type == UntypedFloatType)
-        return types.f64;
 
     if (type->kind == TypeKind_Void) {
         return NULL;
@@ -623,3 +620,5 @@ void debugPos(LLVMGen *gen, llvm::IRBuilder<> *b, Position pos) {
     if (!FlagDebug) { return; }
     b->SetCurrentDebugLocation(llvm::DebugLoc::get(pos.line, pos.column, gen->d->scope));
 }
+
+#pragma clang diagnostic pop

--- a/src/types.h
+++ b/src/types.h
@@ -26,9 +26,6 @@ extern Type *IntptrType;
 extern Type *UintptrType;
 extern Type *RawptrType;
 
-extern Type *UntypedIntType;
-extern Type *UntypedFloatType;
-
 extern Symbol *FalseSymbol;
 extern Symbol *TrueSymbol;
 
@@ -59,8 +56,7 @@ typedef enum TypeKind {
 
 typedef u8 TypeFlag;
 #define TypeFlag_None 0
-#define TypeFlag_Untyped  0x80
-#define TypeFlag_Alias    0x40
+#define TypeFlag_Alias    0x80
 
 // Void
 #define TypeFlag_NoReturn 0x1
@@ -143,5 +139,9 @@ struct Type {
 extern "C" {
 const char *DescribeType(Type *type);
 const char *DescribeTypeKind(TypeKind kind);
+Type *SmallestIntTypeForValue(u64 val);
+i64 SignExtend(Type *type, Type *target, Val val);
+b32 TypesIdentical(Type *type, Type *target);
+u64 MaxValueForIntOrPointerType(Type *type);
 }
 #endif

--- a/tools/TestSuite.m
+++ b/tools/TestSuite.m
@@ -79,6 +79,10 @@ void setSelfForTestCase(XCTestCase *testCase) {
     test_checkConstantDeclarations();
 }
 
+- (void)test_coercionsAreMarked {
+    test_coercionsAreMarked();
+}
+
 - (void)test_checkConstantUnaryExpressions {
     test_checkConstantUnaryExpressions();
 }
@@ -197,6 +201,10 @@ void setSelfForTestCase(XCTestCase *testCase) {
 - (void) setUp {
     setSelfForTestCase(self);
     [self setContinueAfterFailure: false];
+}
+
+- (void)test_SmallestIntTypeForValue {
+    test_SmallestIntTypeForValue();
 }
 
 - (void)test_TypeIntern {


### PR DESCRIPTION
Integer literals now default to the smallest Signed Integer type that will fit them or `u64` if required.
Float literals default to `f64`.
Nil literals default to `rawptr` with a constant value of `0` which can coerce to any other pointer.