### PR TITLE
Use constant value directly to ensure loss of information does not occur

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -90,6 +90,11 @@ extern "C" {
 #define GB(x) (MB(x)*1024LL)
 #define TB(x) (GB(x)*1024LL)
 
+// https://stackoverflow.com/a/28703383
+#define BITMASK(__TYPE__, __ONE_COUNT__) \
+    ((__TYPE__) (-((__ONE_COUNT__) != 0))) \
+    & (((__TYPE__) -1) >> ((sizeof(__TYPE__) * CHAR_BIT) - (__ONE_COUNT__)))
+
 #define For(agg) for (size_t i = 0; i < ArrayLen(agg); i++)
 
 typedef uint8_t  u8;

--- a/src/constant_eval.c
+++ b/src/constant_eval.c
@@ -3,46 +3,54 @@ i64 evalUnarySigned(TokenKind op, Val val);
 u64 evalUnaryUnsigned(TokenKind op, Val val);
 f64 evalUnaryFloat(TokenKind op, Val val);
 
-b32 evalUnary(TokenKind op, Type *type, ExprInfo *info) {
+b32 evalUnary(TokenKind op, Type *type, ExprInfo *info, b32 *isNegative) {
     if (!info->isConstant) return false;
 
-    b32 isConstant;
+    info->isConstant = true;
     if (IsInteger(type)) {
         if (IsSigned(type)) {
             info->val.i64 = evalUnarySigned(op, info->val);
+            *isNegative = info->val.i64 < 0;
         } else {
             info->val.u64 = evalUnaryUnsigned(op, info->val);
+            *isNegative = op == TK_Sub;
         }
-        isConstant = true;
     } else if (IsFloat(type)) {
         info->val.f64 = evalUnaryFloat(op, info->val);
-        isConstant = true;
+    } else if (isBoolean(type)) {
+        info->val.u64 = evalUnaryUnsigned(op, info->val);
     } else {
         info->val.u64 = 0;
-        isConstant = false;
+        info->isConstant = false;
     }
-    info->isConstant = isConstant;
-    return isConstant;
+
+    if (op == TK_BNot) info->val.u64 &= BITMASK(u64, type->Width);
+
+    return info->isConstant;
 }
 
 i64 evalBinarySigned(TokenKind op, i64 left, i64 right);
 u64 evalBinaryUnsigned(TokenKind op, u64 left, u64 right);
 f64 evalBinaryFloat(TokenKind op, f64 left, f64 right);
 
-b32 evalBinary(TokenKind op, Type *type, Val lhsValue, Val rhsValue, ExprInfo *info) {
+b32 evalBinary(TokenKind op, Type *type, Val lhsValue, Val rhsValue, ExprInfo *info, b32 *isNegative) {
     if (!info->isConstant) return false;
 
     b32 isConstant;
     if (IsInteger(type)) {
         if (IsSigned(type)) {
             info->val.i64 = evalBinarySigned(op, lhsValue.i64, rhsValue.i64);
+            *isNegative = info->val.i64 < 0;
         } else {
             info->val.u64 = evalBinaryUnsigned(op, lhsValue.u64, rhsValue.u64);
+            *isNegative = false;
         }
         isConstant = true;
     } else if (IsFloat(type)) {
         info->val.f64 = evalBinaryFloat(op, lhsValue.f64, rhsValue.f64);
         isConstant = true;
+    } else if (isBoolean(type)) {
+        info->val.u64 = evalBinaryUnsigned(op, lhsValue.u64, rhsValue.u64);
     } else {
         info->val.f64 = 0.f;
         isConstant = false;
@@ -173,6 +181,10 @@ u64 evalBinaryUnsigned(TokenKind op, u64 left, u64 right) {
             return left > right;
         case TK_Geq:
             return left >= right;
+        case TK_Land:
+            return left && right;
+        case TK_Lor:
+            return left || right;
         default:
             PANIC("Invalid binary operation in constant evaluation");
             break;

--- a/src/constant_eval.c
+++ b/src/constant_eval.c
@@ -6,7 +6,6 @@ f64 evalUnaryFloat(TokenKind op, Val val);
 b32 evalUnary(TokenKind op, Type *type, ExprInfo *info, b32 *isNegative) {
     if (!info->isConstant) return false;
 
-    info->isConstant = true;
     if (IsInteger(type)) {
         if (IsSigned(type)) {
             info->val.i64 = evalUnarySigned(op, info->val);
@@ -36,7 +35,6 @@ f64 evalBinaryFloat(TokenKind op, f64 left, f64 right);
 b32 evalBinary(TokenKind op, Type *type, Val lhsValue, Val rhsValue, ExprInfo *info, b32 *isNegative) {
     if (!info->isConstant) return false;
 
-    b32 isConstant;
     if (IsInteger(type)) {
         if (IsSigned(type)) {
             info->val.i64 = evalBinarySigned(op, lhsValue.i64, rhsValue.i64);
@@ -45,19 +43,16 @@ b32 evalBinary(TokenKind op, Type *type, Val lhsValue, Val rhsValue, ExprInfo *i
             info->val.u64 = evalBinaryUnsigned(op, lhsValue.u64, rhsValue.u64);
             *isNegative = false;
         }
-        isConstant = true;
     } else if (IsFloat(type)) {
         info->val.f64 = evalBinaryFloat(op, lhsValue.f64, rhsValue.f64);
-        isConstant = true;
     } else if (isBoolean(type)) {
         info->val.u64 = evalBinaryUnsigned(op, lhsValue.u64, rhsValue.u64);
     } else {
         info->val.f64 = 0.f;
-        isConstant = false;
+        info->isConstant = false;
     }
-    info->isConstant = isConstant;
 
-    return isConstant;
+    return info->isConstant;
 }
 
 i64 evalUnarySigned(TokenKind op, Val val) {

--- a/src/types.c
+++ b/src/types.c
@@ -50,18 +50,28 @@ const char *DescribeTypeKind(TypeKind kind) {
     return TypeKindDescriptions[kind];
 }
 
-Type *SmallestIntTypeForValue(u64 val) {
-    val = MAX(val, INT8_MAX);
-    if (val == INT8_MAX) return I8Type;
+Type *SmallestIntTypeForNegativeValue(i64 val) {
+    val = MIN(val, INT8_MIN);
+    if (val == INT8_MIN) return I8Type;
 
-    val = MAX(val, INT16_MAX);
-    if (val == INT16_MAX) return I16Type;
+    val = MIN(val, INT16_MIN);
+    if (val == INT16_MIN) return I16Type;
 
-    val = MAX(val, INT32_MAX);
-    if (val == INT32_MAX) return I32Type;
+    val = MIN(val, INT32_MIN);
+    if (val == INT32_MIN) return I32Type;
 
-    val = MAX(val, INT64_MAX);
-    if (val == INT64_MAX) return I64Type;
+    return I64Type;
+}
+
+Type *SmallestIntTypeForPositiveValue(u64 val) {
+    val = MAX(val, UINT8_MAX);
+    if (val == UINT8_MAX) return U8Type;
+
+    val = MAX(val, UINT16_MAX);
+    if (val == UINT16_MAX) return U16Type;
+
+    val = MAX(val, UINT32_MAX);
+    if (val == UINT32_MAX) return U32Type;
 
     return U64Type;
 }
@@ -83,6 +93,13 @@ i64 SignExtend(Type *type, Type *target, Val val) {
     return (v ^ mask) - mask;
 }
 
+i64 SignExtendTo64Bits(Type *source, Val val) {
+    if (source->Width == 64) return val.i64;
+    u64 v = val.u64 & ((1ull << source->Width) - 1);
+    u64 mask = 1ull << (source->Width - 1);
+    return (v ^ mask) - mask;
+}
+
 b32 isAlias(Type *type);
 b32 TypesIdentical(Type *type, Type *target) {
     while (isAlias(type)) {
@@ -98,12 +115,11 @@ b32 TypesIdentical(Type *type, Type *target) {
 void test_SmallestIntTypeForValue() {
     INIT_COMPILER();
 
-    ASSERT(SmallestIntTypeForValue(0) == I8Type);
-    ASSERT(SmallestIntTypeForValue(INT8_MAX) == I8Type);
-    ASSERT(SmallestIntTypeForValue(INT16_MAX) == I16Type);
-    ASSERT(SmallestIntTypeForValue(INT32_MAX) == I32Type);
-    ASSERT(SmallestIntTypeForValue(INT64_MAX) == I64Type);
-    ASSERT(SmallestIntTypeForValue(UINT64_MAX) == U64Type);
+    ASSERT(SmallestIntTypeForPositiveValue(0) == U8Type);
+    ASSERT(SmallestIntTypeForPositiveValue(UINT8_MAX) == U8Type);
+    ASSERT(SmallestIntTypeForPositiveValue(UINT16_MAX) == U16Type);
+    ASSERT(SmallestIntTypeForPositiveValue(UINT32_MAX) == U32Type);
+    ASSERT(SmallestIntTypeForPositiveValue(UINT64_MAX) == U64Type);
 }
 #endif
 

--- a/src/types.h
+++ b/src/types.h
@@ -139,8 +139,10 @@ struct Type {
 extern "C" {
 const char *DescribeType(Type *type);
 const char *DescribeTypeKind(TypeKind kind);
-Type *SmallestIntTypeForValue(u64 val);
+Type *SmallestIntTypeForPositiveValue(u64 val);
+Type *SmallestIntTypeForNegativeValue(i64 val);
 i64 SignExtend(Type *type, Type *target, Val val);
+i64 SignExtendTo64Bits(Type *source, Val val);
 b32 TypesIdentical(Type *type, Type *target);
 u64 MaxValueForIntOrPointerType(Type *type);
 }


### PR DESCRIPTION
This is done by expanding types as needed for constant values.
See the following 2 coercion rules:
> Signed to Unsigned - Source is a positive constant less than Target's Max Value
> Unsigned to Signed - Source is a constant less than Target's Max Value