### PR TITLE
Use anonymous enums to make stored enumerations a u8

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -1,7 +1,7 @@
-#define EXPR_KIND_START       0x100
-#define STMT_KIND_START       0x200
-#define DECL_KIND_START       0x300
-#define AST_KIND_START        0x400
+
+#define EXPR_KIND_START       0x20
+#define STMT_KIND_START       0x40
+#define DECL_KIND_START       0x80
 
 #define EXPR_KINDS                                           \
     FOR_EACH(Ident, "identifier", true)                      \
@@ -53,7 +53,8 @@
     FOR_EACH(Constant, "constant", true) \
     FOR_EACH(Import, "import", true)
 
-typedef enum ExprKind {
+typedef u8 ExprKind;
+enum {
     ExprKind_Invalid = 0,
     
     _ExprKind_Start = EXPR_KIND_START,
@@ -61,31 +62,33 @@ typedef enum ExprKind {
     EXPR_KINDS
 #undef FOR_EACH
         _ExprKind_End,
-} ExprKind;
+};
 
-typedef enum StmtKind {
+typedef u8 StmtKind;
+enum StmtKind {
     StmtKind_Invalid = 0,
     
     _StmtKind_Start = STMT_KIND_START,
 #define FOR_EACH(kindName, ...) StmtKind_##kindName,
     STMT_KINDS
 #undef FOR_EACH
-        _StmtKind_End,
+    _StmtKind_End,
     
     _StmtExprKind_Start = EXPR_KIND_START,
 #define FOR_EACH(kindName, ...) StmtExprKind_##kindName,
     EXPR_KINDS
 #undef FOR_EACH
-        _StmtExprKind_End,
+    _StmtExprKind_End,
     
     _StmtDeclKind_Start = DECL_KIND_START,
 #define FOR_EACH(kindName, ...) StmtDeclKind_##kindName,
     DECL_KINDS
 #undef FOR_EACH
-        _StmtDeclKind_End
-} StmtKind;
+    _StmtDeclKind_End
+};
 
-typedef enum DeclKind {
+typedef u8 DeclKind;
+enum {
     DeclKind_Invalid = 0,
     
     _DeclKind_Start = DECL_KIND_START,
@@ -93,8 +96,11 @@ typedef enum DeclKind {
     DECL_KINDS
 #undef FOR_EACH
         _DeclKind_End,
-} DeclKind;
+};
 
+STATIC_ASSERT(_ExprKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
+STATIC_ASSERT(_StmtKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
+STATIC_ASSERT(_DeclKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
 
 typedef struct Expr Expr;
 typedef struct Stmt Stmt;
@@ -191,15 +197,15 @@ struct Expr_Autocast {
     Expr *expr;
 };
 
-typedef enum KeyValueFlags {
-    KeyValueFlagIndex = 1,
-} KeyValueFlags;
+typedef u8 KeyValueFlag;
+enum {
+    KeyValueFlag_Index = 1,
+};
 struct Expr_KeyValue {
     Position start;
-    // TODO: We should add support for C style {['0'] = 0; ['1'] = 1; } which may will require a different key type
     Expr *key; 
     Expr *value;
-    u8 flags;
+    KeyValueFlag flags;
 };
 
 struct Expr_LocationDirective {
@@ -291,13 +297,14 @@ struct Expr_TypePolymorphic {
     const char *name;
 };
 
-typedef enum TypeVariadicFlags {
-    TypeVariadicFlagCVargs = 1,
-} TypeVariadicFlags;
+typedef u8 TypeVariadicFlag;
+enum {
+    TypeVariadicFlag_CVargs = 1,
+};
 struct Expr_TypeVariadic {
     Position start;
     Expr *type;
-    b8 flags;
+    TypeVariadicFlag flags;
 };
 
 struct Expr_TypeFunction {

--- a/src/ast.h
+++ b/src/ast.h
@@ -65,7 +65,7 @@ enum {
 };
 
 typedef u8 StmtKind;
-enum StmtKind {
+enum {
     StmtKind_Invalid = 0,
     
     _StmtKind_Start = STMT_KIND_START,
@@ -98,9 +98,9 @@ enum {
         _DeclKind_End,
 };
 
-STATIC_ASSERT(_ExprKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
-STATIC_ASSERT(_StmtKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
-STATIC_ASSERT(_DeclKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
+STATIC_ASSERT(_ExprKind_End <= UINT8_MAX, "enum values overflow storage type");
+STATIC_ASSERT(_StmtKind_End <= UINT8_MAX, "enum values overflow storage type");
+STATIC_ASSERT(_DeclKind_End <= UINT8_MAX, "enum values overflow storage type");
 
 typedef struct Expr Expr;
 typedef struct Stmt Stmt;
@@ -203,7 +203,7 @@ enum {
 };
 struct Expr_KeyValue {
     Position start;
-    Expr *key; 
+    Expr *key;
     Expr *value;
     KeyValueFlag flags;
 };

--- a/src/checker.c
+++ b/src/checker.c
@@ -686,7 +686,7 @@ Type *checkExprTypeVariadic(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_TypeVariadic);
     Type *type = checkExpr(expr->TypeVariadic.type, ctx, pkg);
     if (!expectType(pkg, type, ctx, expr->TypeVariadic.type->start)) goto error;
-    TypeFlag flags = expr->TypeVariadic.flags & TypeVariadicFlagCVargs ? TypeFlag_CVargs : TypeFlag_None;
+    TypeFlag flags = expr->TypeVariadic.flags & TypeVariadicFlag_CVargs ? TypeFlag_CVargs : TypeFlag_None;
     type = NewTypeSlice(flags, type);
     ctx->mode = ExprMode_Type;
     return type;

--- a/src/checker.c
+++ b/src/checker.c
@@ -1,5 +1,6 @@
 
-typedef enum __attribute__((packed)) ExprMode {
+typedef u8 ExprMode;
+enum {
     // Signals to the caller in the checker
     ExprMode_Invalid,
     ExprMode_Unresolved,
@@ -16,7 +17,7 @@ typedef enum __attribute__((packed)) ExprMode {
     ExprMode_Addressable,
 
     // NOTE: Order matters if anything is above addressable must also be addressable
-} ExprMode;
+};
 
 typedef struct CheckerContext CheckerContext;
 struct CheckerContext {

--- a/src/checker.h
+++ b/src/checker.h
@@ -11,7 +11,7 @@ enum {
     NUM_CHECKER_INFO_KINDS,
 };
 
-STATIC_ASSERT(_StmtKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
+STATIC_ASSERT(_StmtKind_End <= UINT8_MAX, "enum values overflow storage type");
 
 typedef u8 Conversion;
 #define ConversionClass_Mask 0x07  // Lower 3 bits denote the class

--- a/src/checker.h
+++ b/src/checker.h
@@ -1,5 +1,6 @@
 
-typedef enum CheckerInfoKind {
+typedef u8 CheckerInfoKind;
+enum {
     // None is the zero value and so the default for zero initialized checker info.
     CheckerInfoKind_None,
     CheckerInfoKind_Constant,
@@ -7,7 +8,10 @@ typedef enum CheckerInfoKind {
     CheckerInfoKind_Ident,
     CheckerInfoKind_Selector,
     CheckerInfoKind_BasicExpr,
-} CheckerInfoKind;
+    NUM_CHECKER_INFO_KINDS,
+};
+
+STATIC_ASSERT(_StmtKind_End < UINT8_MAX, "Enumeration stored in u8 has case past 255, overflow will occur");
 
 typedef u8 Conversion;
 #define ConversionClass_Mask 0x07  // Lower 3 bits denote the class

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -61,7 +61,7 @@ enum {
     NUM_TOKEN_KINDS,
 };
 
-STATIC_ASSERT(NUM_TOKEN_KINDS < UINT8_MAX, "TokenKind is a u8 with more than 255 token kinds overflow will occur");
+STATIC_ASSERT(NUM_TOKEN_KINDS <= UINT8_MAX, "enum values overflow storage type");
 
 #define TokenAssignOffset(Kind) Kind - (TK_AddAssign - TK_Add)
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -53,12 +53,15 @@
     FOR_EACH(Terminator, ";") \
     FOR_EACH(Keyword, "")
 
-typedef enum TokenKind {
+typedef u8 TokenKind;
+enum {
 #define FOR_EACH(e, s) TK_##e,
     TOKEN_KINDS
 #undef FOR_EACH
     NUM_TOKEN_KINDS,
-} TokenKind;
+};
+
+STATIC_ASSERT(NUM_TOKEN_KINDS < UINT8_MAX, "TokenKind is a u8 with more than 255 token kinds overflow will occur");
 
 #define TokenAssignOffset(Kind) Kind - (TK_AddAssign - TK_Add)
 

--- a/src/main.c
+++ b/src/main.c
@@ -84,7 +84,7 @@ int main(int argc, const char **argv) {
         CheckerWork *work = QueueDequeue(&checkingQueue);
         if (work) {
             CheckerContext ctx = { .scope = work->package->scope };
-            b32 shouldRequeue = checkStmt(work->package, work->stmt, &ctx);
+            b32 shouldRequeue = checkStmt(work->stmt, &ctx, work->package);
             if (shouldRequeue) {
                 QueueEnqueue(&checkingQueue, work);
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -214,7 +214,7 @@ Expr *parseExprAtom(Parser *p) {
         caseEllipsis: // For `case TK_Directive` for #cvargs
         case TK_Ellipsis: {
             u8 flags = 0;
-            flags |= matchDirective(p, internCVargs) ? TypeVariadicFlagCVargs : 0;
+            flags |= matchDirective(p, internCVargs) ? TypeVariadicFlag_CVargs : 0;
             Position start = p->tok.pos;
             expectToken(p, TK_Ellipsis); // NOTE: We must expect here because we handle the case of having #cvargs prior
             return NewExprTypeVariadic(pkg, start, parseType(p), flags);
@@ -547,7 +547,7 @@ Expr_KeyValue *parseExprCompoundField(Parser *p) {
     Expr_KeyValue *field = AllocAst(p->package, sizeof(Expr_KeyValue));
     field->start = p->tok.pos;
     if (matchToken(p, TK_Lbrack)) {
-        field->flags = KeyValueFlagIndex;
+        field->flags = KeyValueFlag_Index;
         field->key = parseExpr(p, false);
         expectToken(p, TK_Rbrack);
         expectToken(p, TK_Colon);
@@ -1077,7 +1077,7 @@ ASSERT(!parserTestPackage.diagnostics.errors)
     ASSERT(ArrayLen(expr->LitCompound.elements) == 3);
     ASSERT_EXPR_KIND(ExprKind_LitCompound);
     ASSERT(ArrayLen(expr->LitCompound.elements) == 3);
-    ASSERT(expr->LitCompound.elements[0]->flags & KeyValueFlagIndex);
+    ASSERT(expr->LitCompound.elements[0]->flags & KeyValueFlag_Index);
 
 #undef ASSERT_EXPR_KIND
 }

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -1,5 +1,6 @@
 
-typedef enum SymbolKind {
+typedef u8 SymbolKind;
+enum {
     SymbolKind_Invalid,
 
     SymbolKind_Import,
@@ -9,13 +10,14 @@ typedef enum SymbolKind {
 
     SymbolKind_Constant,
     SymbolKind_Variable,
-} SymbolKind;
+};
 
-typedef enum SymbolState {
+typedef u8 SymbolState;
+enum {
     SymbolState_Unresolved,
     SymbolState_Resolving,
     SymbolState_Resolved,
-} SymbolState;
+};
 
 typedef struct Decl Decl;
 typedef struct Type Type;

--- a/src/types.h
+++ b/src/types.h
@@ -43,12 +43,13 @@ extern Symbol *TrueSymbol;
     FOR_EACH(Function, "function")  \
     FOR_EACH(Tuple, "tuple")        \
 
-typedef enum TypeKind {
+typedef u8 TypeKind;
+enum {
 #define FOR_EACH(kind, ...) TypeKind_##kind,
     TYPE_KINDS
 #undef FOR_EACH
     NUM_TYPE_KINDS,
-} TypeKind;
+};
 
 #define FOR_EACH(kind, ...) typedef struct Type_##kind Type_##kind;
     TYPE_KINDS


### PR DESCRIPTION
Use the following pattern when an `enum` may be stored in memory.
```c
typedef u8 TokenKind;
enum {
    // ...
    NUM_TOKEN_KINDS,
};

STATIC_ASSERT(NUM_TOKEN_KINDS <= UINT8_MAX, "enum values overflow storage type");
```