### PR TITLE
Update the backend

### DIFF
--- a/src/checker.h
+++ b/src/checker.h
@@ -1,6 +1,6 @@
 
 typedef u8 CheckerInfoKind;
-enum {
+enum CheckerInfoKindEnum {
     // None is the zero value and so the default for zero initialized checker info.
     CheckerInfoKind_None,
     CheckerInfoKind_Constant,
@@ -19,18 +19,19 @@ enum {
 STATIC_ASSERT(_StmtKind_End <= UINT8_MAX, "enum values overflow storage type");
 
 typedef u8 Conversion;
-#define ConversionClass_Mask 0x07  // Lower 3 bits denote the class
-#define ConversionClass_None 0
-#define ConversionClass_Same 1
-#define ConversionClass_FtoI 2
-#define ConversionClass_ItoF 3
-#define ConversionClass_PtoI 4
-#define ConversionClass_ItoP 5
-#define ConversionClass_Bool 6
-#define ConversionClass_Any  7
+#define ConversionKind_Mask 0x07  // Lower 3 bits denote the class
+#define ConversionKind_None 0
+#define ConversionKind_Same 1
+#define ConversionKind_FtoI 2
+#define ConversionKind_ItoF 3
+#define ConversionKind_PtoI 4
+#define ConversionKind_ItoP 5
+#define ConversionKind_Bool 6
+#define ConversionKind_Any  7
 
 #define ConversionFlag_Extend 0x10 // 0001
 #define ConversionFlag_Signed 0x20 // 0010
+#define ConversionFlag_Float  0x40 // 0100 (Source type is a Float)
 
 typedef struct CheckerInfo_Constant CheckerInfo_Constant;
 struct CheckerInfo_Constant {
@@ -79,19 +80,16 @@ typedef struct CheckerInfo_For CheckerInfo_For;
 struct CheckerInfo_For {
     Symbol *continueTarget;
     Symbol *breakTarget;
-    // TODO
 };
 
 typedef struct CheckerInfo_Switch CheckerInfo_Switch;
 struct CheckerInfo_Switch {
     Symbol *breakTarget;
-    // TODO
 };
 
 typedef struct CheckerInfo_Case CheckerInfo_Case;
 struct CheckerInfo_Case {
     Symbol *fallthroughTarget;
-    // TODO
 };
 
 STATIC_ASSERT(offsetof(CheckerInfo_Ident,     coerce) == 0, "conversion must be at offset 0 for expressions");
@@ -120,6 +118,7 @@ struct CheckerInfo {
 extern "C" {
 #endif
 Symbol *Lookup(Scope *scope, const char *name);
+Type *TypeFromCheckerInfo(CheckerInfo info);
 b32 IsInteger(Type *type);
 b32 IsSigned(Type *type);
 b32 IsFloat(Type *type);

--- a/src/types.c
+++ b/src/types.c
@@ -300,15 +300,13 @@ void InitBuiltins() {
     _global = Alloc(DefaultAllocator, sizeof(Type)); \
     memcpy(_global, _alias, sizeof(Type)); \
     _global->Symbol = _alias->Symbol; \
-    _global->Flags |= TypeFlag_Alias
+    _global->Flags |= TypeFlag_Alias; \
+    declareBuiltinType(_name, _alias)
 
     TYPE(InvalidType, "<invalid>", Invalid, 0, TypeFlag_None);
     nextTypeId--;
 
     // @IMPORTANT: The order is important here as it sets up the TypeId's
-    // The TypeId's are used to rank numeric types for type promotion
-    //  We can promote compatible types upwards (as ordered below) provided there can be no loss of information
-    //
     TYPE(AnyType,   "any",  Any, 128, TypeFlag_None); // typeid = 1
     TYPE(VoidType, "void", Tuple, 0, TypeFlag_None);
 

--- a/src/types.h
+++ b/src/types.h
@@ -44,7 +44,7 @@ extern Symbol *TrueSymbol;
     FOR_EACH(Tuple, "tuple")        \
 
 typedef u8 TypeKind;
-enum {
+enum TypeKindEnum {
 #define FOR_EACH(kind, ...) TypeKind_##kind,
     TYPE_KINDS
 #undef FOR_EACH

--- a/test/ack.kai
+++ b/test/ack.kai
@@ -1,13 +1,10 @@
 
-#import kai("posix")
-
-ack :: fn(m, n: u32) -> u32 {
+ack :: fn(m, n: int) -> int {
     if m == 0 return n + 1
     if n == 0 return ack(m - 1, 1)
     return ack(m - 1, ack(m, n - 1))
 }
 
-main :: fn() -> void {
-    x := ack(3, 1)
-    posix.printf("%u\n".raw, x)
+main :: fn() -> int {
+    return ack(3, 1)
 }

--- a/tools/TestSuite.m
+++ b/tools/TestSuite.m
@@ -115,8 +115,16 @@ void setSelfForTestCase(XCTestCase *testCase) {
     test_checkConstantCastExpression();
 }
 
+- (void)test_checkExprLitInteger {
+    test_checkExprLitInteger();
+}
+
 - (void)test_checkExprLitFunction {
     test_checkExprLitFunction();
+}
+
+- (void)test_checkExprLitCompound {
+    test_checkExprLitCompound();
 }
 
 - (void)test_checkStmtAssign {
@@ -355,6 +363,10 @@ void setSelfForTestCase(XCTestCase *testCase) {
 
 - (void)test_parseStmt {
     test_parseStmt();
+}
+
+- (void)test_automaticTerminatorAfterFunction {
+    test_automaticTerminatorAfterFunction();
 }
 
 - (void)test_parseStruct {


### PR DESCRIPTION
To start with the largest change is dropping `LLVMGen` altogether, opting to replace it with `Context` (should probably get a prefix on its name).

This will change function signatures from:
```cpp
llvm::Value *emitExpr(LLVMGen *gen, llvm::IRBuilder<> *b, DynamicArray(CheckerInfo) checkerInfo, Expr *expr)
```
to
```cpp
llvm::Value *emitExpr(Context *ctx, Expr *expr)
```

Short & Sweet.

Also adds backend support for function literals & returns