### PR TITLE
Improve errors

### DIFF
--- a/OUTSTANDING.md
+++ b/OUTSTANDING.md
@@ -1,0 +1,12 @@
+# Improve Errors
+
+Update the error formatting desired may be to do something like the following
+
+```kai
+    libc.printf("argc = %d\n", argc)
+    ^~~~
+ERROR: Undeclared identifier 'libc'
+    libc.printf("argv[0] = %s\n", argv[0])
+    ^~~~
+```
+

--- a/kai.xcodeproj/project.pbxproj
+++ b/kai.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_CFLAGS = (
 					"-Wno-c99-extensions",
 					"-Wno-c11-extensions",
@@ -501,7 +501,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_CFLAGS = (
 					"-Wno-c99-extensions",
 					"-Wno-c11-extensions",

--- a/kai.xcodeproj/xcshareddata/xcschemes/kai.xcscheme
+++ b/kai.xcodeproj/xcshareddata/xcschemes/kai.xcscheme
@@ -83,16 +83,20 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-no-error-colors"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "$SRCROOT/test/ack.kai"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$SRCROOT/test/tmp.kai"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$SRCROOT/test/wip.kai"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>

--- a/src/ast.c
+++ b/src/ast.c
@@ -114,21 +114,18 @@ Decl *NewDecl(Package *package, DeclKind kind, Position start) {
     return d;
 }
 
-Expr *NewExprInvalid(Package *package, Position start, Position end) {
+Expr *NewExprInvalid(Package *package, Position start) {
     Expr *e = NewExpr(package, ExprKind_Invalid, start);
-    e->Invalid.end = end;
     return e;
 }
 
-Stmt *NewStmtInvalid(Package *package, Position start, Position end) {
+Stmt *NewStmtInvalid(Package *package, Position start) {
     Stmt *s = NewStmt(package, StmtKind_Invalid, start);
-    s->Invalid.end = end;
     return s;
 }
 
-Decl *NewDeclInvalid(Package *package, Position start, Position end) {
+Decl *NewDeclInvalid(Package *package, Position start) {
     Decl *d = NewDecl(package, DeclKind_Invalid, start);
-    d->Invalid.end = end;
     return d;
 }
 
@@ -138,43 +135,38 @@ Expr *NewExprIdent(Package *package, Position start, const char *name) {
     return e;
 }
 
-Expr *NewExprParen(Package *package, Expr *expr, Position start, Position end) {
+Expr *NewExprParen(Package *package, Expr *expr, Position start) {
     Expr *e = NewExpr(package, ExprKind_Paren, start);
     e->Paren.expr = expr;
-    e->Paren.end = end;
     return e;
 }
 
-Expr *NewExprCall(Package *package, Expr *expr, DynamicArray(Expr_KeyValue *) args, Position end) {
+Expr *NewExprCall(Package *package, Expr *expr, DynamicArray(Expr_KeyValue *) args) {
     Expr *e = NewExpr(package, ExprKind_Call, expr->start);
     e->Call.expr = expr;
     e->Call.args = args;
-    e->Call.end = end;
     return e;
 }
 
-Expr *NewExprSelector(Package *package, Expr *expr, const char *name, Position end) {
+Expr *NewExprSelector(Package *package, Expr *expr, const char *name) {
     Expr *e = NewExpr(package, ExprKind_Selector, expr->start);
     e->Selector.expr = expr;
     e->Selector.name = name;
-    e->Selector.end = end;
     return e;
 }
 
-Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index, Position end) {
+Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index) {
     Expr *e = NewExpr(package, ExprKind_Subscript, expr->start);
     e->Subscript.expr = expr;
     e->Subscript.index = index;
-    e->Subscript.end = end;
     return e;
 }
 
-Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi, Position end) {
+Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi) {
     Expr *e = NewExpr(package, ExprKind_Slice, expr->start);
     e->Slice.expr = expr;
     e->Slice.lo = lo;
     e->Slice.hi = hi;
-    e->Slice.end = end;
     return e;
 }
 
@@ -185,7 +177,7 @@ Expr *NewExprUnary(Package *package, Position start, TokenKind op, Expr *expr) {
     return e;
 }
 
-Expr *NewExprBinary(Package *package, TokenKind op, Position pos, Expr *lhs, Expr *rhs) {
+Expr *NewExprBinary(Package *package, Token op, Position pos, Expr *lhs, Expr *rhs) {
     Expr *e = NewExpr(package, ExprKind_Binary, lhs->start);
     e->Binary.op = op;
     e->Binary.pos = pos;
@@ -251,11 +243,10 @@ Expr *NewExprLitString(Package *package, Position start, const char *val) {
     return e;
 }
 
-Expr *NewExprLitCompound(Package *package, Position start, Expr *type, DynamicArray(Expr_KeyValue *) elements, Position end) {
+Expr *NewExprLitCompound(Package *package, Position start, Expr *type, DynamicArray(Expr_KeyValue *) elements) {
     Expr *e = NewExpr(package, ExprKind_LitCompound, start);
     e->LitCompound.type = type;
     e->LitCompound.elements = elements;
-    e->LitCompound.end = end;
     return e;
 }
 
@@ -367,10 +358,9 @@ Stmt *NewStmtGoto(Package *package, Position start, const char *keyword, Expr *t
     return s;
 }
 
-Stmt *NewStmtBlock(Package *package, Position start, DynamicArray(Stmt *) stmts, Position end) {
+Stmt *NewStmtBlock(Package *package, Position start, DynamicArray(Stmt *) stmts) {
     Stmt *s = NewStmt(package, StmtKind_Block, start);
     s->Block.stmts = stmts;
-    s->Block.end = end;
     return s;
 }
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -72,40 +72,26 @@ void *AllocAst(Package *package, size_t size) {
     return mem;
 }
 
-// TODO: We can implement these correctly to improve error quality at some point
-// Alternatively we *may* be able to come up with something smarter
-Position EndForStmt(Stmt *stmt) {
-    return stmt->start;
-}
-
-Position EndForExpr(Expr *expr) {
-    return expr->start;
-}
-
-Position EndForDecl(Decl *decl) {
-    return decl->start;
-}
-
-Expr *NewExpr(Package *package, ExprKind kind, Position start) {
+Expr *NewExpr(Package *package, ExprKind kind, SourceRange pos) {
     Expr *e = AllocAst(package, sizeof(Expr));
     e->kind = kind;
-    e->start = start;
+    e->pos = pos;
     e->id = DoesStmtKindAllocateTypeInfo[kind] ? ++package->astIdCount: 0;
     return e;
 }
 
-Stmt *NewStmt(Package *package, StmtKind kind, Position start) {
+Stmt *NewStmt(Package *package, StmtKind kind, SourceRange pos) {
     Stmt *s = AllocAst(package, sizeof(Stmt));
     s->kind = kind;
-    s->start = start;
+    s->pos = pos;
     s->id = DoesStmtKindAllocateTypeInfo[kind] ? ++package->astIdCount: 0;
     return s;
 }
 
-Decl *NewDecl(Package *package, DeclKind kind, Position start) {
+Decl *NewDecl(Package *package, DeclKind kind, SourceRange pos) {
     Decl *d = AllocAst(package, sizeof(Decl));
     d->kind = kind;
-    d->start = start;
+    d->pos = pos;
     d->id = DoesStmtKindAllocateTypeInfo[kind] ? ++package->astIdCount: 0;
 
 #if DEBUG
@@ -114,265 +100,265 @@ Decl *NewDecl(Package *package, DeclKind kind, Position start) {
     return d;
 }
 
-Expr *NewExprInvalid(Package *package, Position start) {
-    Expr *e = NewExpr(package, ExprKind_Invalid, start);
+Expr *NewExprInvalid(Package *package, SourceRange pos) {
+    Expr *e = NewExpr(package, ExprKind_Invalid, pos);
     return e;
 }
 
-Stmt *NewStmtInvalid(Package *package, Position start) {
-    Stmt *s = NewStmt(package, StmtKind_Invalid, start);
+Stmt *NewStmtInvalid(Package *package, SourceRange pos) {
+    Stmt *s = NewStmt(package, StmtKind_Invalid, pos);
     return s;
 }
 
-Decl *NewDeclInvalid(Package *package, Position start) {
-    Decl *d = NewDecl(package, DeclKind_Invalid, start);
+Decl *NewDeclInvalid(Package *package, SourceRange pos) {
+    Decl *d = NewDecl(package, DeclKind_Invalid, pos);
     return d;
 }
 
-Expr *NewExprIdent(Package *package, Position start, const char *name) {
-    Expr *e = NewExpr(package, ExprKind_Ident, start);
+Expr *NewExprIdent(Package *package, SourceRange pos, const char *name) {
+    Expr *e = NewExpr(package, ExprKind_Ident, pos);
     e->Ident.name = name;
     return e;
 }
 
-Expr *NewExprParen(Package *package, Expr *expr, Position start) {
-    Expr *e = NewExpr(package, ExprKind_Paren, start);
+Expr *NewExprParen(Package *package, SourceRange pos, Expr *expr) {
+    Expr *e = NewExpr(package, ExprKind_Paren, pos);
     e->Paren.expr = expr;
     return e;
 }
 
-Expr *NewExprCall(Package *package, Expr *expr, DynamicArray(Expr_KeyValue *) args) {
-    Expr *e = NewExpr(package, ExprKind_Call, expr->start);
+Expr *NewExprCall(Package *package, SourceRange pos, Expr *expr, DynamicArray(Expr_KeyValue *) args) {
+    Expr *e = NewExpr(package, ExprKind_Call, pos);
     e->Call.expr = expr;
     e->Call.args = args;
     return e;
 }
 
-Expr *NewExprSelector(Package *package, Expr *expr, const char *name) {
-    Expr *e = NewExpr(package, ExprKind_Selector, expr->start);
+Expr *NewExprSelector(Package *package, SourceRange pos, Expr *expr, const char *name) {
+    Expr *e = NewExpr(package, ExprKind_Selector, pos);
     e->Selector.expr = expr;
     e->Selector.name = name;
     return e;
 }
 
-Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index) {
-    Expr *e = NewExpr(package, ExprKind_Subscript, expr->start);
+Expr *NewExprSubscript(Package *package, SourceRange pos, Expr *expr, Expr *index) {
+    Expr *e = NewExpr(package, ExprKind_Subscript, pos);
     e->Subscript.expr = expr;
     e->Subscript.index = index;
     return e;
 }
 
-Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi) {
-    Expr *e = NewExpr(package, ExprKind_Slice, expr->start);
+Expr *NewExprSlice(Package *package, SourceRange pos, Expr *expr, Expr *lo, Expr *hi) {
+    Expr *e = NewExpr(package, ExprKind_Slice, pos);
     e->Slice.expr = expr;
     e->Slice.lo = lo;
     e->Slice.hi = hi;
     return e;
 }
 
-Expr *NewExprUnary(Package *package, Position start, TokenKind op, Expr *expr) {
-    Expr *e = NewExpr(package, ExprKind_Unary, start);
+Expr *NewExprUnary(Package *package, SourceRange pos, TokenKind op, Expr *expr) {
+    Expr *e = NewExpr(package, ExprKind_Unary, pos);
     e->Unary.op = op;
     e->Unary.expr = expr;
     return e;
 }
 
-Expr *NewExprBinary(Package *package, Token op, Expr *lhs, Expr *rhs) {
-    Expr *e = NewExpr(package, ExprKind_Binary, lhs->start);
+Expr *NewExprBinary(Package *package, SourceRange pos, Token op, Expr *lhs, Expr *rhs) {
+    Expr *e = NewExpr(package, ExprKind_Binary, pos);
     e->Binary.op = op;
     e->Binary.lhs = lhs;
     e->Binary.rhs = rhs;
     return e;
 }
 
-Expr *NewExprTernary(Package *package, Expr *cond, Expr *pass, Expr *fail) {
-    Expr *e = NewExpr(package, ExprKind_Ternary, cond->start);
+Expr *NewExprTernary(Package *package, SourceRange pos, Expr *cond, Expr *pass, Expr *fail) {
+    Expr *e = NewExpr(package, ExprKind_Ternary, pos);
     e->Ternary.cond = cond;
     e->Ternary.pass = pass;
     e->Ternary.fail = fail;
     return e;
 }
 
-Expr *NewExprCast(Package *package, Position start, Expr *type, Expr *expr) {
-    Expr *e = NewExpr(package, ExprKind_Cast, start);
+Expr *NewExprCast(Package *package, SourceRange pos, Expr *type, Expr *expr) {
+    Expr *e = NewExpr(package, ExprKind_Cast, pos);
     e->Cast.type = type;
     e->Cast.expr = expr;
     return e;
 }
 
-Expr *NewExprAutocast(Package *package, Position start, Expr *expr) {
-    Expr *e = NewExpr(package, ExprKind_Autocast, start);
+Expr *NewExprAutocast(Package *package, SourceRange pos, Expr *expr) {
+    Expr *e = NewExpr(package, ExprKind_Autocast, pos);
     e->Autocast.expr = expr;
     return e;
 }
 
 Expr *NewExprKeyValue(Package *package, Expr *key, Expr *value) {
-    Expr *e = NewExpr(package, ExprKind_KeyValue, key->start);
+    Expr *e = NewExpr(package, ExprKind_KeyValue, key->pos);
     e->KeyValue.key = key;
     e->KeyValue.value = value;
     return e;
 }
 
-Expr *NewExprLocationDirective(Package *package, Position start, const char *name) {
-    Expr *e = NewExpr(package, ExprKind_LocationDirective, start);
+Expr *NewExprLocationDirective(Package *package, SourceRange pos, const char *name) {
+    Expr *e = NewExpr(package, ExprKind_LocationDirective, pos);
     e->LocationDirective.name = name;
     return e;
 }
 
-Expr *NewExprLitNil(Package *package, Position start) {
-    Expr *e = NewExpr(package, ExprKind_LitNil, start);
+Expr *NewExprLitNil(Package *package, SourceRange pos) {
+    Expr *e = NewExpr(package, ExprKind_LitNil, pos);
     return e;
 }
 
-Expr *NewExprLitInt(Package *package, Position start, u64 val) {
-    Expr *e = NewExpr(package, ExprKind_LitInt, start);
+Expr *NewExprLitInt(Package *package, SourceRange pos, u64 val) {
+    Expr *e = NewExpr(package, ExprKind_LitInt, pos);
     e->LitInt.val = val;
     return e;
 }
 
-Expr *NewExprLitFloat(Package *package, Position start, f64 val) {
-    Expr *e = NewExpr(package, ExprKind_LitFloat, start);
+Expr *NewExprLitFloat(Package *package, SourceRange pos, f64 val) {
+    Expr *e = NewExpr(package, ExprKind_LitFloat, pos);
     e->LitFloat.val = val;
     return e;
 }
 
-Expr *NewExprLitString(Package *package, Position start, const char *val) {
-    Expr *e = NewExpr(package, ExprKind_LitString, start);
+Expr *NewExprLitString(Package *package, SourceRange pos, const char *val) {
+    Expr *e = NewExpr(package, ExprKind_LitString, pos);
     e->LitString.val = val;
     return e;
 }
 
-Expr *NewExprLitCompound(Package *package, Position start, Expr *type, DynamicArray(Expr_KeyValue *) elements) {
-    Expr *e = NewExpr(package, ExprKind_LitCompound, start);
+Expr *NewExprLitCompound(Package *package, SourceRange pos, Expr *type, DynamicArray(Expr_KeyValue *) elements) {
+    Expr *e = NewExpr(package, ExprKind_LitCompound, pos);
     e->LitCompound.type = type;
     e->LitCompound.elements = elements;
     return e;
 }
 
-Expr *NewExprLitFunction(Package *package, Expr *type, Stmt_Block *body, u8 flags) {
-    Expr *e = NewExpr(package, ExprKind_LitFunction, type->start);
+Expr *NewExprLitFunction(Package *package, SourceRange pos, Expr *type, Stmt_Block *body, u8 flags) {
+    Expr *e = NewExpr(package, ExprKind_LitFunction, pos);
     e->LitFunction.type = type;
     e->LitFunction.body = body;
     e->LitFunction.flags = flags;
     return e;
 }
 
-Expr *NewExprTypePointer(Package *package, Position start, Expr *type) {
-    Expr *e = NewExpr(package, ExprKind_TypePointer, start);
+Expr *NewExprTypePointer(Package *package, SourceRange pos, Expr *type) {
+    Expr *e = NewExpr(package, ExprKind_TypePointer, pos);
     e->TypePointer.type = type;
     return e;
 }
 
-Expr *NewExprTypeArray(Package *package, Position start, Expr *length, Expr *type) {
-    Expr *e = NewExpr(package, ExprKind_TypeArray, start);
+Expr *NewExprTypeArray(Package *package, SourceRange pos, Expr *length, Expr *type) {
+    Expr *e = NewExpr(package, ExprKind_TypeArray, pos);
     e->TypeArray.length = length;
     e->TypeArray.type = type;
     return e;
 }
 
-Expr *NewExprTypeSlice(Package *package, Position start, Expr *type) {
-    Expr *e = NewExpr(package, ExprKind_TypeSlice, start);
+Expr *NewExprTypeSlice(Package *package, SourceRange pos, Expr *type) {
+    Expr *e = NewExpr(package, ExprKind_TypeSlice, pos);
     e->TypeSlice.type = type;
     return e;
 }
 
-Expr *NewExprTypeStruct(Package *package, Position start, DynamicArray(AggregateItem) items) {
-    Expr *e = NewExpr(package, ExprKind_TypeStruct, start);
+Expr *NewExprTypeStruct(Package *package, SourceRange pos, DynamicArray(AggregateItem) items) {
+    Expr *e = NewExpr(package, ExprKind_TypeStruct, pos);
     e->TypeStruct.items = items;
     return e;
 }
 
-Expr *NewExprTypeEnum(Package *package, Position start, Expr *explicitType, DynamicArray(EnumItem) items) {
-    Expr *e = NewExpr(package, ExprKind_TypeEnum, start);
+Expr *NewExprTypeEnum(Package *package, SourceRange pos, Expr *explicitType, DynamicArray(EnumItem) items) {
+    Expr *e = NewExpr(package, ExprKind_TypeEnum, pos);
     e->TypeEnum.explicitType = explicitType;
     e->TypeEnum.items = items;
     return e;
 }
 
-Expr *NewExprTypeUnion(Package *package, Position start, DynamicArray(AggregateItem) items) {
-    Expr *e = NewExpr(package, ExprKind_TypeUnion, start);
+Expr *NewExprTypeUnion(Package *package, SourceRange pos, DynamicArray(AggregateItem) items) {
+    Expr *e = NewExpr(package, ExprKind_TypeUnion, pos);
     e->TypeUnion.items = items;
     return e;
 }
 
-Expr *NewExprTypePolymorphic(Package *package, Position start, const char *name) {
-    Expr *e = NewExpr(package, ExprKind_TypePolymorphic, start);
+Expr *NewExprTypePolymorphic(Package *package, SourceRange pos, const char *name) {
+    Expr *e = NewExpr(package, ExprKind_TypePolymorphic, pos);
     e->TypePolymorphic.name = name;
     return e;
 }
 
-Expr *NewExprTypeVariadic(Package *package, Position start, Expr *type, u8 flags) {
-    Expr *e = NewExpr(package, ExprKind_TypeVariadic, start);
+Expr *NewExprTypeVariadic(Package *package, SourceRange pos, Expr *type, u8 flags) {
+    Expr *e = NewExpr(package, ExprKind_TypeVariadic, pos);
     e->TypeVariadic.type = type;
     e->TypeVariadic.flags = flags;
     return e;
 }
 
-Expr *NewExprTypeFunction(Package *package, Position start, DynamicArray(Expr_KeyValue *) params, DynamicArray(Expr *)result) {
-    Expr *e = NewExpr(package, ExprKind_TypeFunction, start);
+Expr *NewExprTypeFunction(Package *package, SourceRange pos, DynamicArray(Expr_KeyValue *) params, DynamicArray(Expr *)result) {
+    Expr *e = NewExpr(package, ExprKind_TypeFunction, pos);
     e->TypeFunction.params = params;
     e->TypeFunction.result = result;
     return e;
 }
 
-Stmt *NewStmtEmpty(Package *package, Position start) {
-    return NewStmt(package, StmtKind_Empty, start);
+Stmt *NewStmtEmpty(Package *package, SourceRange pos) {
+    return NewStmt(package, StmtKind_Empty, pos);
 }
 
-Stmt *NewStmtLabel(Package *package, Position start, const char *name) {
-    Stmt *s = NewStmt(package, StmtKind_Label, start);
+Stmt *NewStmtLabel(Package *package, SourceRange pos, const char *name) {
+    Stmt *s = NewStmt(package, StmtKind_Label, pos);
     s->Label.name = name;
     return s;
 }
 
-Stmt *NewStmtAssign(Package *package, Position start, DynamicArray(Expr *) lhs, DynamicArray(Expr*) rhs) {
-    Stmt *s = NewStmt(package, StmtKind_Assign, start);
+Stmt *NewStmtAssign(Package *package, SourceRange pos, DynamicArray(Expr *) lhs, DynamicArray(Expr*) rhs) {
+    Stmt *s = NewStmt(package, StmtKind_Assign, pos);
     s->Assign.lhs = lhs;
     s->Assign.rhs = rhs;
     return s;
 }
 
-Stmt *NewStmtReturn(Package *package, Position start, DynamicArray(Expr *) exprs) {
-    Stmt *s = NewStmt(package, StmtKind_Return, start);
+Stmt *NewStmtReturn(Package *package, SourceRange pos, DynamicArray(Expr *) exprs) {
+    Stmt *s = NewStmt(package, StmtKind_Return, pos);
     s->Return.exprs = exprs;
     return s;
 }
 
-Stmt *NewStmtDefer(Package *package, Position start, Stmt *stmt) {
-    Stmt *s = NewStmt(package, StmtKind_Defer, start);
+Stmt *NewStmtDefer(Package *package, SourceRange pos, Stmt *stmt) {
+    Stmt *s = NewStmt(package, StmtKind_Defer, pos);
     s->Defer.stmt = stmt;
     return s;
 }
 
-Stmt *NewStmtUsing(Package *package, Position start, Expr *expr) {
-    Stmt *s = NewStmt(package, StmtKind_Using, start);
+Stmt *NewStmtUsing(Package *package, SourceRange pos, Expr *expr) {
+    Stmt *s = NewStmt(package, StmtKind_Using, pos);
     s->Using.expr = expr;
     return s;
 }
 
-Stmt *NewStmtGoto(Package *package, Position start, const char *keyword, Expr *target) {
-    Stmt *s = NewStmt(package, StmtKind_Goto, start);
+Stmt *NewStmtGoto(Package *package, SourceRange pos, const char *keyword, Expr *target) {
+    Stmt *s = NewStmt(package, StmtKind_Goto, pos);
     s->Goto.keyword = keyword;
     s->Goto.target = target;
     return s;
 }
 
-Stmt *NewStmtBlock(Package *package, Position start, DynamicArray(Stmt *) stmts) {
-    Stmt *s = NewStmt(package, StmtKind_Block, start);
+Stmt *NewStmtBlock(Package *package, SourceRange pos, DynamicArray(Stmt *) stmts) {
+    Stmt *s = NewStmt(package, StmtKind_Block, pos);
     s->Block.stmts = stmts;
     return s;
 }
 
-Stmt *NewStmtIf(Package *package, Position start, Expr *cond, Stmt *pass, Stmt *fail) {
-    Stmt *s = NewStmt(package, StmtKind_If, start);
+Stmt *NewStmtIf(Package *package, SourceRange pos, Expr *cond, Stmt *pass, Stmt *fail) {
+    Stmt *s = NewStmt(package, StmtKind_If, pos);
     s->If.cond = cond;
     s->If.pass = pass;
     s->If.fail = fail;
     return s;
 }
 
-Stmt *NewStmtFor(Package *package, Position start, Stmt *init, Expr *cond, Stmt *step, Stmt_Block *body) {
-    Stmt *s = NewStmt(package, StmtKind_For, start);
+Stmt *NewStmtFor(Package *package, SourceRange pos, Stmt *init, Expr *cond, Stmt *step, Stmt_Block *body) {
+    Stmt *s = NewStmt(package, StmtKind_For, pos);
     s->For.init = init;
     s->For.cond = cond;
     s->For.step = step;
@@ -380,8 +366,8 @@ Stmt *NewStmtFor(Package *package, Position start, Stmt *init, Expr *cond, Stmt 
     return s;
 }
 
-Stmt *NewStmtForIn(Package *package, Position start, Expr_Ident *valueName, Expr_Ident *indexName, Expr *aggregate, Stmt_Block *body) {
-    Stmt *s = NewStmt(package, StmtKind_ForIn, start);
+Stmt *NewStmtForIn(Package *package, SourceRange pos, Expr_Ident *valueName, Expr_Ident *indexName, Expr *aggregate, Stmt_Block *body) {
+    Stmt *s = NewStmt(package, StmtKind_ForIn, pos);
     s->ForIn.valueName = valueName;
     s->ForIn.indexName = indexName;
     s->ForIn.aggregate = aggregate;
@@ -389,39 +375,38 @@ Stmt *NewStmtForIn(Package *package, Position start, Expr_Ident *valueName, Expr
     return s;
 }
 
-Stmt *NewStmtSwitch(Package *package, Position start, Expr *match, DynamicArray(Stmt *) cases) {
-    Stmt *s = NewStmt(package, StmtKind_Switch, start);
+Stmt *NewStmtSwitch(Package *package, SourceRange pos, Expr *match, DynamicArray(Stmt *) cases) {
+    Stmt *s = NewStmt(package, StmtKind_Switch, pos);
     s->Switch.match = match;
     s->Switch.cases = cases;
     return s;
 }
 
-Stmt *NewStmtSwitchCase(Package *package, Position start, DynamicArray(Expr *) matches, Stmt_Block *block) {
-    Stmt *s = NewStmt(package, StmtKind_SwitchCase, start);
-    s->SwitchCase.start = start;
+Stmt *NewStmtSwitchCase(Package *package, SourceRange pos, DynamicArray(Expr *) matches, Stmt_Block *block) {
+    Stmt *s = NewStmt(package, StmtKind_SwitchCase, pos);
     s->SwitchCase.matches = matches;
     s->SwitchCase.block = block;
     return s;
 }
 
-Decl *NewDeclVariable(Package *package, Position start, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values) {
-    Decl *d = NewDecl(package, DeclKind_Variable, start);
+Decl *NewDeclVariable(Package *package, SourceRange pos, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values) {
+    Decl *d = NewDecl(package, DeclKind_Variable, pos);
     d->Variable.names = names;
     d->Variable.type = type;
     d->Variable.values = values;
     return d;
 }
 
-Decl *NewDeclConstant(Package *package, Position start, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values) {
-    Decl *d = NewDecl(package, DeclKind_Constant, start);
+Decl *NewDeclConstant(Package *package, SourceRange pos, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values) {
+    Decl *d = NewDecl(package, DeclKind_Constant, pos);
     d->Constant.names = names;
     d->Constant.type = type;
     d->Constant.values = values;
     return d;
 }
 
-Decl *NewDeclForeign(Package *package, Position start, Expr *library, bool isConstant, const char *name, Expr *type, const char *linkname, const char *callingConvention) {
-    Decl *d = NewDecl(package, DeclKind_Foreign, start);
+Decl *NewDeclForeign(Package *package, SourceRange pos, Expr *library, bool isConstant, const char *name, Expr *type, const char *linkname, const char *callingConvention) {
+    Decl *d = NewDecl(package, DeclKind_Foreign, pos);
     d->Foreign.library = library;
     d->Foreign.isConstant = isConstant;
     d->Foreign.name = name;
@@ -431,16 +416,16 @@ Decl *NewDeclForeign(Package *package, Position start, Expr *library, bool isCon
     return d;
 }
 
-Decl *NewDeclForeignBlock(Package *package, Position start, Expr *library, const char *callingConvention, DynamicArray(Decl_ForeignBlockMember) members) {
-    Decl *d = NewDecl(package, DeclKind_ForeignBlock, start);
+Decl *NewDeclForeignBlock(Package *package, SourceRange pos, Expr *library, const char *callingConvention, DynamicArray(Decl_ForeignBlockMember) members) {
+    Decl *d = NewDecl(package, DeclKind_ForeignBlock, pos);
     d->ForeignBlock.library = library;
     d->ForeignBlock.members = members;
     d->ForeignBlock.callingConvention = callingConvention;
     return d;
 }
 
-Decl *NewDeclImport(Package *package, Position start, Expr *path, const char *alias) {
-    Decl *d = NewDecl(package, DeclKind_Import, start);
+Decl *NewDeclImport(Package *package, SourceRange pos, Expr *path, const char *alias) {
+    Decl *d = NewDecl(package, DeclKind_Import, pos);
     d->Import.path = path;
     d->Import.alias = alias;
     return d;

--- a/src/ast.c
+++ b/src/ast.c
@@ -177,10 +177,9 @@ Expr *NewExprUnary(Package *package, Position start, TokenKind op, Expr *expr) {
     return e;
 }
 
-Expr *NewExprBinary(Package *package, Token op, Position pos, Expr *lhs, Expr *rhs) {
+Expr *NewExprBinary(Package *package, Token op, Expr *lhs, Expr *rhs) {
     Expr *e = NewExpr(package, ExprKind_Binary, lhs->start);
     e->Binary.op = op;
-    e->Binary.pos = pos;
     e->Binary.lhs = lhs;
     e->Binary.rhs = rhs;
     return e;

--- a/src/ast.c
+++ b/src/ast.c
@@ -434,7 +434,7 @@ Decl *NewDeclImport(Package *package, SourceRange pos, Expr *path, const char *a
 #if TEST
 void test_isExpr_and_isDecl() {
     Package pkg = {0};
-    Position pos = {0};
+    SourceRange pos = {0};
     Stmt *expr = (Stmt *) NewExprIdent(&pkg, pos, NULL);
     ASSERT(isExpr(expr));
     

--- a/src/ast.h
+++ b/src/ast.h
@@ -125,7 +125,6 @@ DECL_KINDS
 typedef struct AstInvalid AstInvalid;
 struct AstInvalid {
     Position start;
-    Position end;
 };
 
 struct Expr_Ident {
@@ -136,28 +135,24 @@ struct Expr_Ident {
 struct Expr_Paren {
     Position start;
     Expr *expr;
-    Position end;
 };
 
 struct Expr_Call {
     Position start;
     Expr *expr;
     DynamicArray(Expr_KeyValue *) args;
-    Position end;
 };
 
 struct Expr_Selector {
     Position start;
     Expr *expr;
     const char *name;
-    Position end;
 };
 
 struct Expr_Subscript {
     Position start;
     Expr *expr;
     Expr *index;
-    Position end;
 };
 
 struct Expr_Slice {
@@ -165,7 +160,6 @@ struct Expr_Slice {
     Expr *expr;
     Expr *lo;
     Expr *hi;
-    Position end;
 };
 
 struct Expr_Unary {
@@ -176,7 +170,7 @@ struct Expr_Unary {
 
 struct Expr_Binary {
     Position start;
-    TokenKind op;
+    Token op;
     Position pos;
     Expr *lhs;
     Expr *rhs;
@@ -248,7 +242,6 @@ struct Expr_LitCompound {
     Position start;
     Expr *type;
     DynamicArray(Expr_KeyValue *) elements;
-    Position end;
 };
 
 struct Expr_LitFunction {
@@ -364,7 +357,6 @@ struct Stmt_Goto {
 struct Stmt_Block {
     Position start;
     DynamicArray(Stmt *) stmts;
-    Position end;
 };
 
 struct Stmt_If {
@@ -554,17 +546,17 @@ Position EndForDecl(Decl *decl);
 Expr *NewExpr(Package *package, ExprKind kind, Position start);
 Stmt *NewStmt(Package *package, StmtKind kind, Position start);
 Decl *NewDecl(Package *package, DeclKind kind, Position start);
-Expr *NewExprInvalid(Package *package, Position start, Position end);
-Stmt *NewStmtInvalid(Package *package, Position start, Position end);
-Decl *NewDeclInvalid(Package *package, Position start, Position end);
+Expr *NewExprInvalid(Package *package, Position start);
+Stmt *NewStmtInvalid(Package *package, Position start);
+Decl *NewDeclInvalid(Package *package, Position start);
 Expr *NewExprIdent(Package *package, Position start, const char *name);
-Expr *NewExprParen(Package *package, Expr *expr, Position start, Position end);
-Expr *NewExprCall(Package *package, Expr *expr, DynamicArray(Expr_KeyValue *) args, Position end);
-Expr *NewExprSelector(Package *package, Expr *expr, const char *name, Position end);
-Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index, Position end);
-Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi, Position end);
+Expr *NewExprParen(Package *package, Expr *expr, Position start);
+Expr *NewExprCall(Package *package, Expr *expr, DynamicArray(Expr_KeyValue *) args);
+Expr *NewExprSelector(Package *package, Expr *expr, const char *name);
+Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index);
+Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi);
 Expr *NewExprUnary(Package *package, Position start, TokenKind op, Expr *expr);
-Expr *NewExprBinary(Package *package, TokenKind op, Position pos, Expr *lhs, Expr *rhs);
+Expr *NewExprBinary(Package *package, Token op, Position pos, Expr *lhs, Expr *rhs);
 Expr *NewExprTernary(Package *package, Expr *cond, Expr *pass, Expr *fail);
 Expr *NewExprCast(Package *package, Position start, Expr *type, Expr *expr);
 Expr *NewExprAutocast(Package *package, Position start, Expr *expr);
@@ -574,7 +566,7 @@ Expr *NewExprLitNil(Package *package, Position start);
 Expr *NewExprLitInt(Package *package, Position start, u64 val);
 Expr *NewExprLitFloat(Package *package, Position start, f64 val);
 Expr *NewExprLitString(Package *package, Position start, const char *val);
-Expr *NewExprLitCompound(Package *package, Position start, Expr *type, DynamicArray(Expr_KeyValue *) elements, Position end);
+Expr *NewExprLitCompound(Package *package, Position start, Expr *type, DynamicArray(Expr_KeyValue *) elements);
 Expr *NewExprLitFunction(Package *package, Expr *type, Stmt_Block *body, u8 flags);
 Expr *NewExprTypePointer(Package *package, Position start, Expr *type);
 Expr *NewExprTypeArray(Package *package, Position start, Expr *length, Expr *type);
@@ -594,7 +586,7 @@ Stmt *NewStmtReturn(Package *package, Position start, DynamicArray(Expr *) exprs
 Stmt *NewStmtDefer(Package *package, Position start, Stmt *stmt);
 Stmt *NewStmtUsing(Package *package, Position start, Expr *expr);
 Stmt *NewStmtGoto(Package *package, Position start, const char *keyword, Expr *target);
-Stmt *NewStmtBlock(Package *package, Position start, DynamicArray(Stmt *) stmts, Position end);
+Stmt *NewStmtBlock(Package *package, Position start, DynamicArray(Stmt *) stmts);
 Stmt *NewStmtIf(Package *package, Position start, Expr *cond, Stmt *pass, Stmt *fail);
 Stmt *NewStmtFor(Package *package, Position start, Stmt *init, Expr *cond, Stmt *step, Stmt_Block *body);
 Stmt *NewStmtForIn(Package *package, Position start, Expr_Ident *valueName, Expr_Ident *indexName, Expr *aggregate, Stmt_Block *body);

--- a/src/ast.h
+++ b/src/ast.h
@@ -105,6 +105,7 @@ STATIC_ASSERT(_ExprKind_End <= UINT8_MAX, "enum values overflow storage type");
 STATIC_ASSERT(_StmtKind_End <= UINT8_MAX, "enum values overflow storage type");
 STATIC_ASSERT(_DeclKind_End <= UINT8_MAX, "enum values overflow storage type");
 
+typedef void * AstNode;
 typedef struct Expr Expr;
 typedef struct Stmt Stmt;
 typedef struct Decl Decl;
@@ -124,72 +125,72 @@ DECL_KINDS
 
 typedef struct AstInvalid AstInvalid;
 struct AstInvalid {
-    Position start;
+    SourceRange pos;
 };
 
 struct Expr_Ident {
-    Position start;
+    SourceRange pos;
     const char *name;
 };
 
 struct Expr_Paren {
-    Position start;
+    SourceRange pos;
     Expr *expr;
 };
 
 struct Expr_Call {
-    Position start;
+    SourceRange pos;
     Expr *expr;
     DynamicArray(Expr_KeyValue *) args;
 };
 
 struct Expr_Selector {
-    Position start;
+    SourceRange pos;
     Expr *expr;
     const char *name;
 };
 
 struct Expr_Subscript {
-    Position start;
+    SourceRange pos;
     Expr *expr;
     Expr *index;
 };
 
 struct Expr_Slice {
-    Position start;
+    SourceRange pos;
     Expr *expr;
     Expr *lo;
     Expr *hi;
 };
 
 struct Expr_Unary {
-    Position start;
+    SourceRange pos;
     TokenKind op;
     Expr *expr;
 };
 
 struct Expr_Binary {
-    Position start;
+    SourceRange pos;
     Token op;
     Expr *lhs;
     Expr *rhs;
 };
 
 struct Expr_Ternary {
-    Position start;
+    SourceRange pos;
     Expr *cond;
     Expr *pass;
     Expr *fail;
 };
 
 struct Expr_Cast {
-    Position start;
+    SourceRange pos;
     Expr *type;
     Expr *expr;
 };
 
 struct Expr_Autocast {
-    Position start;
+    SourceRange pos;
     Expr *expr;
 };
 
@@ -198,7 +199,7 @@ enum Enum_KeyValueFlag {
     KeyValueFlag_Index = 1,
 };
 struct Expr_KeyValue {
-    Position start;
+    SourceRange pos;
     Expr *key;
     Expr *value;
     KeyValueFlag flags;
@@ -214,90 +215,90 @@ struct Expr_KeyValue {
 };
 
 struct Expr_LocationDirective {
-    Position start;
+    SourceRange pos;
     const char *name;
 };
 
 struct Expr_LitNil {
-    Position start;
+    SourceRange pos;
 };
 
 struct Expr_LitInt {
-    Position start;
+    SourceRange pos;
     u64 val;
 };
 
 struct Expr_LitFloat {
-    Position start;
+    SourceRange pos;
     f64 val;
 };
 
 struct Expr_LitString {
-    Position start;
+    SourceRange pos;
     const char *val;
 };
 
 struct Expr_LitCompound {
-    Position start;
+    SourceRange pos;
     Expr *type;
     DynamicArray(Expr_KeyValue *) elements;
 };
 
 struct Expr_LitFunction {
-    Position start;
+    SourceRange pos;
     Expr *type;
     Stmt_Block *body;
     u8 flags;
 };
 
 struct Expr_TypePointer {
-    Position start;
+    SourceRange pos;
     Expr *type;
 };
 
 struct Expr_TypeArray {
-    Position start;
+    SourceRange pos;
     Expr *length;
     Expr *type;
 };
 
 struct Expr_TypeSlice {
-    Position start;
+    SourceRange pos;
     Expr *type;
 };
 
 typedef struct AggregateItem AggregateItem;
 struct AggregateItem {
-    Position start;
+    SourceRange pos;
     DynamicArray(const char *) names;
     Expr *type;
 };
 
 struct Expr_TypeStruct {
-    Position start;
+    SourceRange pos;
     DynamicArray(AggregateItem) items;
 };
 
 struct Expr_TypeUnion {
-    Position start;
+    SourceRange pos;
     DynamicArray(AggregateItem) items;
 };
 
 typedef struct EnumItem EnumItem;
 struct EnumItem {
-    Position start;
+    SourceRange pos;
     const char *name;
     Expr *init;
 };
 
 struct Expr_TypeEnum {
-    Position start;
+    SourceRange pos;
     Expr *explicitType;
     DynamicArray(EnumItem) items;
 };
 
 struct Expr_TypePolymorphic {
-    Position start;
+    SourceRange pos;
     const char *name;
 };
 
@@ -306,67 +307,67 @@ enum Enum_TypeVariadicFlag {
     TypeVariadicFlag_CVargs = 1,
 };
 struct Expr_TypeVariadic {
-    Position start;
+    SourceRange pos;
     Expr *type;
     TypeVariadicFlag flags;
 };
 
 struct Expr_TypeFunction {
-    Position start;
+    SourceRange pos;
     DynamicArray(Expr *) result;
     DynamicArray(Expr_KeyValue *) params;
 };
 
 struct Stmt_Empty {
-    Position start;
+    SourceRange pos;
 };
 
 struct Stmt_Label {
-    Position start;
+    SourceRange pos;
     const char *name;
 };
 
 struct Stmt_Assign {
-    Position start;
+    SourceRange pos;
     DynamicArray(Expr *) lhs;
     DynamicArray(Expr *) rhs;
 };
 
 struct Stmt_Return {
-    Position start;
+    SourceRange pos;
     DynamicArray(Expr *) exprs;
 };
 
 struct Stmt_Defer {
-    Position start;
+    SourceRange pos;
     Stmt *stmt;
 };
 
 struct Stmt_Using {
-    Position start;
+    SourceRange pos;
     Expr *expr;
 };
 
 struct Stmt_Goto {
-    Position start;
+    SourceRange pos;
     const char *keyword;
     Expr *target;
 };
 
 struct Stmt_Block {
-    Position start;
+    SourceRange pos;
     DynamicArray(Stmt *) stmts;
 };
 
 struct Stmt_If {
-    Position start;
+    SourceRange pos;
     Expr *cond;
     Stmt *pass;
     Stmt *fail;
 };
 
 struct Stmt_For {
-    Position start;
+    SourceRange pos;
     Stmt *init;
     Expr *cond;
     Stmt *step;
@@ -374,7 +375,7 @@ struct Stmt_For {
 };
 
 struct Stmt_ForIn {
-    Position start;
+    SourceRange pos;
     Expr_Ident *valueName;
     Expr_Ident *indexName;
     Expr *aggregate;
@@ -382,33 +383,33 @@ struct Stmt_ForIn {
 };
 
 struct Stmt_Switch {
-    Position start;
+    SourceRange pos;
     Expr *match;
     DynamicArray(Stmt *) cases;
 };
 
 struct Stmt_SwitchCase {
-    Position start;
+    SourceRange pos;
     DynamicArray(Expr *) matches;
     Stmt_Block *block;
 };
 
 struct Decl_Variable {
-    Position start;
+    SourceRange pos;
     DynamicArray(Expr_Ident *) names;
     Expr *type;
     DynamicArray(Expr *) values;
 };
 
 struct Decl_Constant {
-    Position start;
+    SourceRange pos;
     DynamicArray(Expr_Ident *) names;
     Expr *type;
     DynamicArray(Expr *) values;
 };
 
 struct Decl_Foreign {
-    Position start;
+    SourceRange pos;
     Expr *library;
     bool isConstant;
     const char *name;
@@ -419,7 +420,7 @@ struct Decl_Foreign {
 
 typedef struct Decl_ForeignBlockMember Decl_ForeignBlockMember;
 struct Decl_ForeignBlockMember {
-    Position start;
+    SourceRange pos;
     const char *name;
     bool isConstant;
     Expr *type;
@@ -428,14 +429,14 @@ struct Decl_ForeignBlockMember {
 };
 
 struct Decl_ForeignBlock {
-    Position start;
+    SourceRange pos;
     Expr *library;
     const char *callingConvention;
     DynamicArray(Decl_ForeignBlockMember) members;
 };
 
 struct Decl_Import {
-    Position start;
+    SourceRange pos;
     Expr *path;
     const char *alias;
     Symbol *symbol;
@@ -466,7 +467,7 @@ struct Stmt {
     u64 id;
     StmtKind kind;
     union {
-        Position start;
+        SourceRange pos;
         StmtValue stmt;
         ExprValue expr;
         DeclValue decl;
@@ -490,7 +491,7 @@ struct Expr {
     u64 id;
     ExprKind kind;
     union {
-        Position start;
+        SourceRange pos;
         ExprValue expr;
         AstInvalid Invalid;
         
@@ -505,7 +506,7 @@ struct Decl {
     u64 id;
     DeclKind kind;
     union {
-        Position start;
+        SourceRange pos;
         DeclValue decl;
         AstInvalid Invalid;
         
@@ -536,65 +537,60 @@ const char *DescribeDecl(Decl *decl);
 
 void *AllocAst(Package *package, size_t size);
 
-// - MARK: Ends
-Position EndForStmt(Stmt *stmt);
-Position EndForExpr(Expr *expr);
-Position EndForDecl(Decl *decl);
-
 // - MARK: Exprs
-Expr *NewExpr(Package *package, ExprKind kind, Position start);
-Stmt *NewStmt(Package *package, StmtKind kind, Position start);
-Decl *NewDecl(Package *package, DeclKind kind, Position start);
-Expr *NewExprInvalid(Package *package, Position start);
-Stmt *NewStmtInvalid(Package *package, Position start);
-Decl *NewDeclInvalid(Package *package, Position start);
-Expr *NewExprIdent(Package *package, Position start, const char *name);
-Expr *NewExprParen(Package *package, Expr *expr, Position start);
-Expr *NewExprCall(Package *package, Expr *expr, DynamicArray(Expr_KeyValue *) args);
-Expr *NewExprSelector(Package *package, Expr *expr, const char *name);
-Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index);
-Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi);
-Expr *NewExprUnary(Package *package, Position start, TokenKind op, Expr *expr);
-Expr *NewExprBinary(Package *package, Token op, Expr *lhs, Expr *rhs);
-Expr *NewExprTernary(Package *package, Expr *cond, Expr *pass, Expr *fail);
-Expr *NewExprCast(Package *package, Position start, Expr *type, Expr *expr);
-Expr *NewExprAutocast(Package *package, Position start, Expr *expr);
+Expr *NewExpr(Package *package, ExprKind kind, SourceRange pos);
+Stmt *NewStmt(Package *package, StmtKind kind, SourceRange pos);
+Decl *NewDecl(Package *package, DeclKind kind, SourceRange pos);
+Expr *NewExprInvalid(Package *package, SourceRange pos);
+Stmt *NewStmtInvalid(Package *package, SourceRange pos);
+Decl *NewDeclInvalid(Package *package, SourceRange pos);
+Expr *NewExprIdent(Package *package, SourceRange pos, const char *name);
+Expr *NewExprParen(Package *package, SourceRange pos, Expr *expr);
+Expr *NewExprCall(Package *package, SourceRange pos, Expr *expr, DynamicArray(Expr_KeyValue *) args);
+Expr *NewExprSelector(Package *package, SourceRange pos, Expr *expr, const char *name);
+Expr *NewExprSubscript(Package *package, SourceRange pos, Expr *expr, Expr *index);
+Expr *NewExprSlice(Package *package, SourceRange pos, Expr *expr, Expr *lo, Expr *hi);
+Expr *NewExprUnary(Package *package, SourceRange pos, TokenKind op, Expr *expr);
+Expr *NewExprBinary(Package *package, SourceRange pos, Token op, Expr *lhs, Expr *rhs);
+Expr *NewExprTernary(Package *package, SourceRange pos, Expr *cond, Expr *pass, Expr *fail);
+Expr *NewExprCast(Package *package, SourceRange pos, Expr *type, Expr *expr);
+Expr *NewExprAutocast(Package *package, SourceRange pos, Expr *expr);
 Expr *NewExprKeyValue(Package *package, Expr *key, Expr *value);
-Expr *NewExprLocationDirective(Package *package, Position start, const char *name);
-Expr *NewExprLitNil(Package *package, Position start);
-Expr *NewExprLitInt(Package *package, Position start, u64 val);
-Expr *NewExprLitFloat(Package *package, Position start, f64 val);
-Expr *NewExprLitString(Package *package, Position start, const char *val);
-Expr *NewExprLitCompound(Package *package, Position start, Expr *type, DynamicArray(Expr_KeyValue *) elements);
-Expr *NewExprLitFunction(Package *package, Expr *type, Stmt_Block *body, u8 flags);
-Expr *NewExprTypePointer(Package *package, Position start, Expr *type);
-Expr *NewExprTypeArray(Package *package, Position start, Expr *length, Expr *type);
-Expr *NewExprTypeSlice(Package *package, Position start, Expr *type);
-Expr *NewExprTypeStruct(Package *package, Position start, DynamicArray(AggregateItem) items);
-Expr *NewExprTypeEnum(Package *package, Position start, Expr *explicitType, DynamicArray(EnumItem) items);
-Expr *NewExprTypeUnion(Package *package, Position start, DynamicArray(AggregateItem) items);
-Expr *NewExprTypePolymorphic(Package *package, Position start, const char *name);
-Expr *NewExprTypeVariadic(Package *package, Position start, Expr *type, u8 flags);
-Expr *NewExprTypeFunction(Package *package, Position start, DynamicArray(Expr_KeyValue *) params, DynamicArray(Expr *)result);
+Expr *NewExprLocationDirective(Package *package, SourceRange pos, const char *name);
+Expr *NewExprLitNil(Package *package, SourceRange pos);
+Expr *NewExprLitInt(Package *package, SourceRange pos, u64 val);
+Expr *NewExprLitFloat(Package *package, SourceRange pos, f64 val);
+Expr *NewExprLitString(Package *package, SourceRange pos, const char *val);
+Expr *NewExprLitCompound(Package *package, SourceRange pos, Expr *type, DynamicArray(Expr_KeyValue *) elements);
+Expr *NewExprLitFunction(Package *package, SourceRange pos, Expr *type, Stmt_Block *body, u8 flags);
+Expr *NewExprTypePointer(Package *package, SourceRange pos, Expr *type);
+Expr *NewExprTypeArray(Package *package, SourceRange pos, Expr *length, Expr *type);
+Expr *NewExprTypeSlice(Package *package, SourceRange pos, Expr *type);
+Expr *NewExprTypeStruct(Package *package, SourceRange pos, DynamicArray(AggregateItem) items);
+Expr *NewExprTypeEnum(Package *package, SourceRange pos, Expr *explicitType, DynamicArray(EnumItem) items);
+Expr *NewExprTypeUnion(Package *package, SourceRange pos, DynamicArray(AggregateItem) items);
+Expr *NewExprTypePolymorphic(Package *package, SourceRange pos, const char *name);
+Expr *NewExprTypeVariadic(Package *package, SourceRange pos, Expr *type, u8 flags);
+Expr *NewExprTypeFunction(Package *package, SourceRange pos, DynamicArray(Expr_KeyValue *) params, DynamicArray(Expr *)result);
 
 // - MARK: Stmts
-Stmt *NewStmtEmpty(Package *package, Position start);
-Stmt *NewStmtLabel(Package *package, Position start, const char *name);
-Stmt *NewStmtAssign(Package *package, Position start, DynamicArray(Expr *) lhs, DynamicArray(Expr*) rhs);
-Stmt *NewStmtReturn(Package *package, Position start, DynamicArray(Expr *) exprs);
-Stmt *NewStmtDefer(Package *package, Position start, Stmt *stmt);
-Stmt *NewStmtUsing(Package *package, Position start, Expr *expr);
-Stmt *NewStmtGoto(Package *package, Position start, const char *keyword, Expr *target);
-Stmt *NewStmtBlock(Package *package, Position start, DynamicArray(Stmt *) stmts);
-Stmt *NewStmtIf(Package *package, Position start, Expr *cond, Stmt *pass, Stmt *fail);
-Stmt *NewStmtFor(Package *package, Position start, Stmt *init, Expr *cond, Stmt *step, Stmt_Block *body);
-Stmt *NewStmtForIn(Package *package, Position start, Expr_Ident *valueName, Expr_Ident *indexName, Expr *aggregate, Stmt_Block *body);
-Stmt *NewStmtSwitch(Package *package, Position start, Expr *match, DynamicArray(Stmt *) cases);
-Stmt *NewStmtSwitchCase(Package *package, Position start, DynamicArray(Expr *) matches, Stmt_Block *block);
+Stmt *NewStmtEmpty(Package *package, SourceRange pos);
+Stmt *NewStmtLabel(Package *package, SourceRange pos, const char *name);
+Stmt *NewStmtAssign(Package *package, SourceRange pos, DynamicArray(Expr *) lhs, DynamicArray(Expr*) rhs);
+Stmt *NewStmtReturn(Package *package, SourceRange pos, DynamicArray(Expr *) exprs);
+Stmt *NewStmtDefer(Package *package, SourceRange pos, Stmt *stmt);
+Stmt *NewStmtUsing(Package *package, SourceRange pos, Expr *expr);
+Stmt *NewStmtGoto(Package *package, SourceRange pos, const char *keyword, Expr *target);
+Stmt *NewStmtBlock(Package *package, SourceRange pos, DynamicArray(Stmt *) stmts);
+Stmt *NewStmtIf(Package *package, SourceRange pos, Expr *cond, Stmt *pass, Stmt *fail);
+Stmt *NewStmtFor(Package *package, SourceRange pos, Stmt *init, Expr *cond, Stmt *step, Stmt_Block *body);
+Stmt *NewStmtForIn(Package *package, SourceRange pos, Expr_Ident *valueName, Expr_Ident *indexName, Expr *aggregate, Stmt_Block *body);
+Stmt *NewStmtSwitch(Package *package, SourceRange pos, Expr *match, DynamicArray(Stmt *) cases);
+Stmt *NewStmtSwitchCase(Package *package, SourceRange pos, DynamicArray(Expr *) matches, Stmt_Block *block);
 
 // - MARK: Decls
-Decl *NewDeclVariable(Package *package, Position start, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values);
-Decl *NewDeclConstant(Package *package, Position start, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values);
-Decl *NewDeclForeign(Package *package, Position start, Expr *library, bool isConstant, const char *name, Expr *type, const char *linkname, const char *callingConvention);
-Decl *NewDeclForeignBlock(Package *package, Position start, Expr *library, const char *callingConvention, DynamicArray(Decl_ForeignBlockMember) members);
-Decl *NewDeclImport(Package *package, Position start, Expr *path, const char *alias);
+Decl *NewDeclVariable(Package *package, SourceRange pos, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values);
+Decl *NewDeclConstant(Package *package, SourceRange pos, DynamicArray(Expr_Ident *) names, Expr *type, DynamicArray(Expr *) values);
+Decl *NewDeclForeign(Package *package, SourceRange pos, Expr *library, bool isConstant, const char *name, Expr *type, const char *linkname, const char *callingConvention);
+Decl *NewDeclForeignBlock(Package *package, SourceRange pos, Expr *library, const char *callingConvention, DynamicArray(Decl_ForeignBlockMember) members);
+Decl *NewDeclImport(Package *package, SourceRange pos, Expr *path, const char *alias);

--- a/src/ast.h
+++ b/src/ast.h
@@ -171,7 +171,6 @@ struct Expr_Unary {
 struct Expr_Binary {
     Position start;
     Token op;
-    Position pos;
     Expr *lhs;
     Expr *rhs;
 };
@@ -556,7 +555,7 @@ Expr *NewExprSelector(Package *package, Expr *expr, const char *name);
 Expr *NewExprSubscript(Package *package, Expr *expr, Expr *index);
 Expr *NewExprSlice(Package *package, Expr *expr, Expr *lo, Expr *hi);
 Expr *NewExprUnary(Package *package, Position start, TokenKind op, Expr *expr);
-Expr *NewExprBinary(Package *package, Token op, Position pos, Expr *lhs, Expr *rhs);
+Expr *NewExprBinary(Package *package, Token op, Expr *lhs, Expr *rhs);
 Expr *NewExprTernary(Package *package, Expr *cond, Expr *pass, Expr *fail);
 Expr *NewExprCast(Package *package, Position start, Expr *type, Expr *expr);
 Expr *NewExprAutocast(Package *package, Position start, Expr *expr);

--- a/src/checker.c
+++ b/src/checker.c
@@ -1369,7 +1369,7 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Type *type = lhs;
 
     if (!binaryPredicates[expr->Binary.op.kind](type)) {
-        ReportError(pkg, InvalidBinaryOperationError, expr->Binary.pos,
+        ReportError(pkg, InvalidBinaryOperationError, expr->Binary.op.pos,
                     "Operation '%s' undefined for type %s",
                     DescribeTokenKind(expr->Binary.op.kind), DescribeType(lhs));
         goto error;

--- a/src/checker.c
+++ b/src/checker.c
@@ -169,8 +169,8 @@ CheckerInfo *CheckerInfoForDecl(Package *pkg, Decl *decl) {
 b32 declareSymbol(Package *pkg, Scope *scope, const char *name, Symbol **symbol, Decl *decl) {
     Symbol *old = Lookup(scope, name);
     if (old) {
-        ReportErrorRange(pkg, RedefinitionError, decl->pos, "Duplicate definition of symbol %s", name);
-        ReportNoteRange(pkg, old->decl->pos, "Previous definition of %s", name);
+        ReportError(pkg, RedefinitionError, decl->pos, "Duplicate definition of symbol %s", name);
+        ReportNote(pkg, old->decl->pos, "Previous definition of %s", name);
         if (symbol) *symbol = old;
         return true;
     }
@@ -205,7 +205,7 @@ Symbol *declareLabelSymbol(Package *pkg, Scope *scope, const char *name) {
 
 b32 expectType(Package *pkg, Type *type, CheckerContext *ctx, SourceRange pos) {
     if (ctx->mode != ExprMode_Type && ctx->mode != ExprMode_Invalid) {
-        ReportErrorRange(pkg, NotATypeError, pos, "%s cannot be used as a type", DescribeTypeKind(type->kind));
+        ReportError(pkg, NotATypeError, pos, "%s cannot be used as a type", DescribeTypeKind(type->kind));
     }
     return true;
 }
@@ -600,7 +600,7 @@ b32 coerceType(Expr *expr, CheckerContext *ctx, Type **type, Type *target, Packa
 
     b32 success = coerceTypeSilently(expr, ctx, type, target, pkg);
     if (!success) {
-        ReportErrorRange(pkg, InvalidConversionError, expr->pos,
+        ReportError(pkg, InvalidConversionError, expr->pos,
                     "Cannot convert %s to type %s", DescribeExpr(expr), DescribeType(target));
         *type = InvalidType;
     }
@@ -689,7 +689,7 @@ Type *checkExprIdent(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Expr_Ident ident = expr->Ident;
     Symbol *symbol = Lookup(ctx->scope, ident.name);
     if (!symbol) {
-        ReportErrorRange(pkg, UndefinedIdentError, expr->pos, "Use of undefined identifier '%s'", ident.name);
+        ReportError(pkg, UndefinedIdentError, expr->pos, "Use of undefined identifier '%s'", ident.name);
         ctx->mode = ExprMode_Invalid;
         return InvalidType;
     }
@@ -707,7 +707,7 @@ Type *checkExprIdent(Expr *expr, CheckerContext *ctx, Package *pkg) {
         case SymbolState_Resolving:
             // TODO: For cyclic types we need a ctx->hasIndirection to check and see if
             // We have a cyclic reference error.
-            ReportErrorRange(pkg, ReferenceToDeclarationError, expr->pos,
+            ReportError(pkg, ReferenceToDeclarationError, expr->pos,
                         "Declaration initial value refers to itself");
             break;
 
@@ -766,10 +766,10 @@ Type *checkExprLitInt(Expr *expr, CheckerContext *ctx, Package *pkg) {
             ctx->val.u64 = lit.val;
 
             if (lit.val > MaxValueForIntOrPointerType(ctx->desiredType)) {
-                ReportErrorRange(pkg, InvalidConversionError, expr->pos,
+                ReportError(pkg, InvalidConversionError, expr->pos,
                             "Cannot coerce value '%s' to type %s as loss of information would occur",
                             DescribeExpr(expr), DescribeType(ctx->desiredType));
-                ReportNoteRange(pkg, expr->pos, "If you wish for this overflow to occur add an explicit cast");
+                ReportNote(pkg, expr->pos, "If you wish for this overflow to occur add an explicit cast");
             }
         } else if (IsFloat(ctx->desiredType)) {
             ctx->val.f64 = (f64)lit.val;
@@ -803,7 +803,7 @@ Type *checkExprLitFloat(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 ctx->val.f64 = lit.val;
             }
         } else {
-            ReportErrorRange(pkg, InvalidConversionError, expr->pos,
+            ReportError(pkg, InvalidConversionError, expr->pos,
                         "Unable to coerce %s to expected type %s",
                         DescribeExpr(expr), DescribeType(ctx->desiredType));
             // TODO: Check if it's possible through casting and add note that you can cast to make the conversion occur @ErrorQuality
@@ -828,7 +828,7 @@ error:
 Type *checkExprLitNil(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_LitNil);
     if (ctx->desiredType && !isNilable(ctx->desiredType)) {
-        ReportErrorRange(pkg, NotNilableError, expr->pos,
+        ReportError(pkg, NotNilableError, expr->pos,
                     "'nil' is not convertable to '%s'", DescribeType(ctx->desiredType));
         goto error;
     }
@@ -918,7 +918,7 @@ Type *checkExprTypeFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     if (isVoid) {
         if (ArrayLen(func.result) > 1) {
-            ReportErrorRange(pkg, InvalidUseOfVoidError, expr->pos,
+            ReportError(pkg, InvalidUseOfVoidError, expr->pos,
                         "Void must be a functions only return type");
         } else {
             ArrayFree(results);
@@ -961,7 +961,7 @@ Type *checkExprLitFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
     // FIXME: We need to extract and pass on desired types parameters & results
     ForEach(func.type->TypeFunction.params, Expr_KeyValue *) {
         if (!it->key || it->key->kind != ExprKind_Ident) {
-            ReportErrorRange(pkg, ParamNameMissingError, it->pos, "Parameters for a function literal must be named");
+            ReportError(pkg, ParamNameMissingError, it->pos, "Parameters for a function literal must be named");
             continue;
         }
 
@@ -1001,7 +1001,7 @@ Type *checkExprLitFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     if (isVoid) {
         if (ArrayLen(func.type->TypeFunction.result) > 1) {
-            ReportErrorRange(pkg, InvalidUseOfVoidError, expr->LitFunction.type->pos,
+            ReportError(pkg, InvalidUseOfVoidError, expr->LitFunction.type->pos,
                         "Void must be a functions only return type");
         } else {
             ArrayFree(results);
@@ -1046,7 +1046,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 case TypeKind_Array:
                 case TypeKind_Slice:
                     if (!(it->flags & KeyValueFlag_Index)) {
-                        ReportErrorRange(pkg, ArrayCompoundMissingIndexError, it->key->pos,
+                        ReportError(pkg, ArrayCompoundMissingIndexError, it->key->pos,
                                     "Array or Slice key should be surrounded in `[]`");
                         goto checkValue;
                     }
@@ -1068,7 +1068,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
                     // Allow 0 length arrays to be indexed freely
                     if (type->kind == TypeKind_Array && type->Array.length && type->Array.length <= currentIndex) {
-                        ReportErrorRange(pkg, TODOError, it->value->pos,
+                        ReportError(pkg, TODOError, it->value->pos,
                                     "Array index %llu is beyond the max index of %llu for type %s",
                                     currentIndex, type->Array.length - 1, DescribeType(type));
                     }
@@ -1079,12 +1079,12 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
                 case TypeKind_Struct:
                     if (it->flags & KeyValueFlag_Index) {
-                        ReportErrorRange(pkg, TODOError, it->key->pos, "Cannot initalize struct members using index");
+                        ReportError(pkg, TODOError, it->key->pos, "Cannot initalize struct members using index");
                         goto checkValue;
                     }
 
                     if (it->key->kind != ExprKind_Ident) {
-                        ReportErrorRange(pkg, TODOError, it->key->pos,
+                        ReportError(pkg, TODOError, it->key->pos,
                                     "Expected identifier for field name for type %s", DescribeType(type));
                         goto checkValue;
                     }
@@ -1093,7 +1093,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
                     StructFieldLookupResult result = StructFieldLookup(type->Struct, fieldName);
                     if (!result.field) {
-                        ReportErrorRange(pkg, TODOError, it->key->pos,
+                        ReportError(pkg, TODOError, it->key->pos,
                                     "Type %s has no field named %s", DescribeType(type), fieldName);
                     }
 
@@ -1111,7 +1111,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 case TypeKind_Array:
                     // Allow 0 length arrays to be indexed freely
                     if (type->Array.length && type->Array.length <= currentIndex) {
-                        ReportErrorRange(pkg, TODOError, it->value->pos,
+                        ReportError(pkg, TODOError, it->value->pos,
                                     "Array index %llu is beyond the max index of %llu for type %s",
                                     currentIndex, type->Array.length - 1, DescribeType(type));
                     }
@@ -1158,11 +1158,11 @@ Type *checkExprTypePointer(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     expectType(pkg, type, ctx, expr->TypePointer.type->pos);
     if (ctx->mode != ExprMode_Type) {
-        ReportErrorRange(pkg, InvalidPointeeTypeError, expr->pos,
+        ReportError(pkg, InvalidPointeeTypeError, expr->pos,
                     "'%s' is not a valid pointee type", DescribeType(type));
         goto error;
     } else if (type == VoidType) {
-        ReportErrorRange(pkg, InvalidPointeeTypeError, expr->TypePointer.type->pos,
+        ReportError(pkg, InvalidPointeeTypeError, expr->TypePointer.type->pos,
                     "Kai does not use void * for raw pointers instead use rawptr");
     }
 
@@ -1191,7 +1191,7 @@ Type *checkExprTypeArray(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode != ExprMode_Type) {
         goto error;
     } else if (type->Width == 0) {
-        ReportErrorRange(pkg, ZeroWidthArrayElementError, expr->TypeArray.type->pos,
+        ReportError(pkg, ZeroWidthArrayElementError, expr->TypeArray.type->pos,
                     "Arrays of zero width elements are not permitted");
     }
 
@@ -1205,9 +1205,9 @@ Type *checkExprTypeArray(Expr *expr, CheckerContext *ctx, Package *pkg) {
         length = ctx->val.u64;
 
         if (!(ctx->flags & CheckerContextFlag_Constant)) {
-            ReportErrorRange(pkg, NonConstantArrayLengthError, expr->TypeArray.length->pos,
+            ReportError(pkg, NonConstantArrayLengthError, expr->TypeArray.length->pos,
                         "An arrays length must be a constant value");
-            ReportNoteRange(pkg, expr->pos, "To infer a length for the array type from the context use `..` as the length");
+            ReportNote(pkg, expr->pos, "To infer a length for the array type from the context use `..` as the length");
         }
     } else {
         // NOTE: We need someway to pass down the length from the caller because we cannot create and later on update
@@ -1243,7 +1243,7 @@ Type *checkExprTypeSlice(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode != ExprMode_Type) {
         goto error;
     } if (type->Width == 0) {
-        ReportErrorRange(pkg, ZeroWidthSliceElementError, expr->TypeSlice.type->pos,
+        ReportError(pkg, ZeroWidthSliceElementError, expr->TypeSlice.type->pos,
                     "Slices of zero width elements are not permitted");
     }
 
@@ -1311,7 +1311,7 @@ Type *checkExprUnary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     switch (expr->Unary.op) {
         case TK_And:
             if (ctx->mode < ExprMode_Addressable) {
-                ReportErrorRange(pkg, AddressOfNonAddressableError, expr->pos,
+                ReportError(pkg, AddressOfNonAddressableError, expr->pos,
                             "Cannot take address of %s", DescribeExpr(expr->Unary.expr));
                 goto error;
             }
@@ -1320,7 +1320,7 @@ Type *checkExprUnary(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
         default:
             if (!unaryPredicates[expr->Unary.op](type)) {
-                ReportErrorRange(pkg, InvalidUnaryOperationError, expr->pos,
+                ReportError(pkg, InvalidUnaryOperationError, expr->pos,
                             "Operation '%s' undefined for %s",
                             DescribeTokenKind(expr->Unary.op), DescribeExpr(expr->Unary.expr));
                 goto error;
@@ -1358,10 +1358,10 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     // TODO: clean this up
     if (!(coerceTypeSilently(expr->Binary.lhs, &lhsCtx, &lhs, rhs, pkg) ||
           coerceTypeSilently(expr->Binary.rhs, &rhsCtx, &rhs, lhs, pkg))) {
-        ReportErrorRange(pkg, TypeMismatchError, expr->pos,
+        ReportError(pkg, TypeMismatchError, expr->pos,
                     "No conversion possible to make %s and %s Identical types",
                     DescribeExpr(expr->Binary.lhs), DescribeExpr(expr->Binary.rhs));
-        ReportNoteRange(pkg, expr->pos, "An explicit cast may be required");
+        ReportNote(pkg, expr->pos, "An explicit cast may be required");
         goto error;
     }
 
@@ -1369,7 +1369,7 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Type *type = lhs;
 
     if (!binaryPredicates[expr->Binary.op.kind](type)) {
-        ReportErrorPosition(pkg, InvalidBinaryOperationError, expr->Binary.op.pos,
+        ReportError(pkg, InvalidBinaryOperationError, rangeFromPosition(expr->Binary.op.pos),
                     "Operation '%s' undefined for type %s",
                     DescribeTokenKind(expr->Binary.op.kind), DescribeType(lhs));
         goto error;
@@ -1394,7 +1394,7 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     }
 
     if ((expr->Binary.op.kind == TK_Div || expr->Binary.op.kind == TK_Rem) && IsConstant(&rhsCtx) && rhsCtx.val.i64 == 0) {
-        ReportErrorRange(pkg, DivisionByZeroError, expr->Binary.rhs->pos, "Division by zero");
+        ReportError(pkg, DivisionByZeroError, expr->Binary.rhs->pos, "Division by zero");
     }
 
     ctx->flags |= lhsCtx.flags & rhsCtx.flags & CheckerContextFlag_Constant;
@@ -1429,7 +1429,7 @@ Type *checkExprTernary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (failCtx.mode == ExprMode_Unresolved)
 
     if (condCtx.mode != ExprMode_Invalid && !isBoolean(cond) && !isNumericOrPointer(cond)) {
-        ReportErrorRange(pkg, BadConditionError, expr->pos,
+        ReportError(pkg, BadConditionError, expr->pos,
                     "Expected a numeric or pointer type to act as a condition in the ternary expression");
         goto error;
     }
@@ -1444,7 +1444,7 @@ Type *checkExprTernary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     } else {
         // NOTE: If we coerce the type before doing handling constant evaluation, we lose signedness information.
         if (!coerceType(expr->Ternary.fail, &failCtx, &fail, pass, pkg)) {
-            ReportErrorRange(pkg, TypeMismatchError, expr->Ternary.fail->pos,
+            ReportError(pkg, TypeMismatchError, expr->Ternary.fail->pos,
                         "Expected type %s got type %s", DescribeType(pass ? pass : cond), DescribeType(fail));
             goto error;
         }
@@ -1482,7 +1482,7 @@ Type *checkExprCast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Type *type = checkExpr(expr->Cast.type, &targetCtx, pkg);
 
     if (targetCtx.mode != ExprMode_Type) {
-        ReportErrorRange(pkg, NotATypeError, expr->pos,
+        ReportError(pkg, NotATypeError, expr->pos,
                     "Cannot cast to non type %s", DescribeExpr(expr->Cast.type));
         goto error;
     }
@@ -1494,7 +1494,7 @@ Type *checkExprCast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Invalid) goto error;
 
     if (!cast(exprType, type, ctx)) {
-        ReportErrorRange(pkg, InvalidConversionError, expr->pos,
+        ReportError(pkg, InvalidConversionError, expr->pos,
                     "Unable to cast type %s to type %s", DescribeType(exprType), DescribeType(type));
         goto error;
     }
@@ -1515,7 +1515,7 @@ error:
 Type *checkExprAutocast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_Autocast);
     if (!ctx->desiredType) {
-        ReportErrorRange(pkg, AutocastExpectsDesiredTypeError, expr->pos,
+        ReportError(pkg, AutocastExpectsDesiredTypeError, expr->pos,
                     "Autocast expression requires a contextual type to convert to");
         goto error;
     }
@@ -1524,7 +1524,7 @@ Type *checkExprAutocast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Invalid) goto error;
 
     if (!cast(type, ctx->desiredType, ctx)) {
-        ReportErrorRange(pkg, InvalidConversionError, expr->Autocast.expr->pos,
+        ReportError(pkg, InvalidConversionError, expr->Autocast.expr->pos,
                     "Cannot convert expression of type %s to type %s",
                     DescribeType(type), DescribeType(ctx->desiredType));
         goto error;
@@ -1548,7 +1548,7 @@ Type *checkExprSubscript(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (indexCtx.mode == ExprMode_Invalid) goto error;
 
     if (!IsInteger(index)) {
-        ReportErrorRange(pkg, InvalidSubscriptIndexTypeError, expr->Subscript.index->pos,
+        ReportError(pkg, InvalidSubscriptIndexTypeError, expr->Subscript.index->pos,
                     "Cannot subscript with non-integer type '%s'",
                     DescribeType(index));
         goto error;
@@ -1563,7 +1563,7 @@ Type *checkExprSubscript(Expr *expr, CheckerContext *ctx, Package *pkg) {
             i64 i = indexCtx.val.i64;
             if (i < 0 || (u64)i >= recv->Array.length) {
                 const char *message = i < 0 ? "before the start" : "after the end of";
-                ReportErrorRange(pkg, OutOfBoundsError, expr->Subscript.index->pos,
+                ReportError(pkg, OutOfBoundsError, expr->Subscript.index->pos,
                             "Index %d is %s of the array (%lu elements)",
                             i, message, recv->Array.length);
                 goto error;
@@ -1581,7 +1581,7 @@ Type *checkExprSubscript(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     default:
         if (recv != InvalidType) {
-            ReportErrorRange(pkg, UnsupportedSubscriptError, expr->Subscript.expr->pos,
+            ReportError(pkg, UnsupportedSubscriptError, expr->Subscript.expr->pos,
                         "Unable to subscript type '%s'",
                         DescribeType(recv));
         }
@@ -1613,7 +1613,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
         case TypeKind_Struct: {
             StructFieldLookupResult result = StructFieldLookup(base->Struct, expr->Selector.name);
             if (!result.field) {
-                ReportErrorRange(pkg, TODOError, expr->Selector.pos, "Struct %s has no member %s",
+                ReportError(pkg, TODOError, expr->Selector.pos, "Struct %s has no member %s",
                             DescribeType(base), expr->Selector.name);
                 goto error;
             }
@@ -1637,7 +1637,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
             Symbol *symbol = Lookup(import->scope, expr->Selector.name);
             if (!symbol) {
-                ReportErrorRange(pkg, TODOError, expr->Selector.pos, "File %s has no member %s",
+                ReportError(pkg, TODOError, expr->Selector.pos, "File %s has no member %s",
                             DescribeExpr(expr->Selector.expr), expr->Selector.name);
                 goto error;
             }
@@ -1649,7 +1649,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 case SymbolState_Resolving:
                     // TODO: For cyclic types we need a ctx->hasIndirection to check and see if
                     // We have a cyclic reference error.
-                    ReportErrorRange(pkg, ReferenceToDeclarationError, expr->pos,
+                    ReportError(pkg, ReferenceToDeclarationError, expr->pos,
                                 "Declaration initial value refers to itself");
                     break;
                 case SymbolState_Resolved:
@@ -1664,7 +1664,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
         }
 
         default: {
-            ReportErrorRange(pkg, TODOError, expr->pos, "%s has no member '%s'", DescribeExpr(expr->Selector.expr), expr->Selector.name);
+            ReportError(pkg, TODOError, expr->pos, "%s has no member '%s'", DescribeExpr(expr->Selector.expr), expr->Selector.name);
             goto error;
         }
     }
@@ -1691,11 +1691,11 @@ Type *checkExprCall(Expr *expr, CheckerContext *ctx, Package *pkg) {
         // This is a cast not a call
 
         if (ArrayLen(expr->Call.args) < 1) {
-            ReportErrorRange(pkg, CastArgumentCountError, expr->pos,
+            ReportError(pkg, CastArgumentCountError, expr->pos,
                         "Missing argument in cast to %s", DescribeType(calleeType));
             goto error;
         } else if (ArrayLen(expr->Call.args) > 1) {
-            ReportErrorRange(pkg, CastArgumentCountError, expr->pos,
+            ReportError(pkg, CastArgumentCountError, expr->pos,
                         "Too many arguments in cast to %s", DescribeType(calleeType));
             goto error;
         }
@@ -1715,7 +1715,7 @@ Type *checkExprCall(Expr *expr, CheckerContext *ctx, Package *pkg) {
         Expr_KeyValue *arg = expr->Call.args[i];
 
         if (i >= nParams && !(calleeType->Function.Flags & TypeFlag_Variadic)) {
-            ReportErrorRange(pkg, TODOError, arg->pos,
+            ReportError(pkg, TODOError, arg->pos,
                         "Too many arguments in call to '%s'", DescribeExpr(expr->Call.expr));
             break;
         }
@@ -1863,7 +1863,7 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
     Decl_Constant constant = decl->Constant;
 
     if (ArrayLen(constant.names) != 1) {
-        ReportErrorRange(pkg, MultipleConstantDeclError, constant.pos,
+        ReportError(pkg, MultipleConstantDeclError, constant.pos,
             "Constant declarations must declare at most one item");
 
         ForEach (constant.names, Expr_Ident *) {
@@ -1874,7 +1874,7 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
     }
 
     if (ArrayLen(constant.values) > 1) {
-        ReportErrorRange(pkg, ArityMismatchError, constant.pos,
+        ReportError(pkg, ArityMismatchError, constant.pos,
                     "Constant declarations only allow for a single value, but got %zu", ArrayLen(constant.values));
         return;
     }
@@ -1936,14 +1936,14 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
     if (exprCtx.mode < ExprMode_Type || (((exprCtx.flags & CheckerContextFlag_Constant) == 0) && (exprCtx.mode != ExprMode_Type))) {
         // The above checks that the expression is constant
         // TODO: Simplify the above ... possibly by shifting around the ExprMode orders so that Addressable is lesser then Value.
-        ReportErrorRange(pkg, NotAValueError, value->pos,
+        ReportError(pkg, NotAValueError, value->pos,
                     "Expected a type or constant value but got %s (type %s)", DescribeExpr(value), DescribeType(type));
     }
 
     symbol->val = exprCtx.val;
 
     if (expectedType && !coerceType(value, &exprCtx, &type, expectedType, pkg)) {
-        ReportErrorRange(pkg, InvalidConversionError, value->pos,
+        ReportError(pkg, InvalidConversionError, value->pos,
                     "Unable to convert type %s to expected type type %s", DescribeType(type), DescribeType(expectedType));
         markSymbolInvalid(symbol);
         return;
@@ -2004,9 +2004,9 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
         }
 
         if (expectedType->kind == TypeKind_Function) {
-            ReportErrorRange(pkg, UninitFunctionTypeError, var.type->pos,
+            ReportError(pkg, UninitFunctionTypeError, var.type->pos,
                 "Variables of a function type must be initialized");
-            ReportNoteRange(pkg, var.type->pos,
+            ReportNote(pkg, var.type->pos,
                        "If you want an uninitialized function pointer use *%s instead", DescribeType(expectedType));
         }
     } else {
@@ -2037,10 +2037,10 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
                     }
 
                     if (expectedType && !coerceTypeSilently(expr, &exprCtx, &ty, expectedType, pkg)) {
-                        ReportErrorRange(pkg, TypeMismatchError, expr->pos,
+                        ReportError(pkg, TypeMismatchError, expr->pos,
                                     "Cannot convert %s to expected type %s",
                                     DescribeType(ty), DescribeType(expectedType));
-                        ReportNoteRange(pkg, expr->pos,
+                        ReportNote(pkg, expr->pos,
                                    "Value comes from the %zu indexed result from call to %s",
                                    rhsIndex, DescribeExpr(expr));
                         // TODO: Use the language value comes from the %zu (st|nd|rd|th) result of the call to %s
@@ -2061,7 +2061,7 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
             }
 
             if (exprCtx.mode < ExprMode_Value) {
-                ReportErrorRange(pkg, NotAValueError, expr->pos,
+                ReportError(pkg, NotAValueError, expr->pos,
                             "Expected a value but got %s (type %s)", DescribeExpr(expr), DescribeType(type));
             } else if (expectedType) {
                 coerceType(expr, &exprCtx, &type, expectedType, pkg);
@@ -2131,7 +2131,7 @@ void checkDeclImport(Decl *decl, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Unresolved) return;
 
     if (!TypesIdentical(type, StringType) || !IsConstant(ctx)) {
-        ReportErrorRange(pkg, TODOError, decl->pos,
+        ReportError(pkg, TODOError, decl->pos,
                     "Could not resolve path %s to string constant", DescribeExpr(decl->Import.path));
         goto error;
     }
@@ -2172,7 +2172,7 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
         } else {
             ArrayPush(lhsTypes, type);
             if (ctx->mode < ExprMode_Addressable && ctx->mode != ExprMode_Invalid) {
-                ReportErrorRange(pkg, ValueNotAssignableError, it->pos,
+                ReportError(pkg, ValueNotAssignableError, it->pos,
                             "Cannot assign to value %s of type %s", DescribeExpr(it), DescribeType(type));
             }
         }
@@ -2208,9 +2208,9 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
                 CheckerInfoForExpr(pkg, assign.lhs[lhsIndex])->coerce = conversion(ty, target);
 
                 if (!coerceTypeSilently(expr, ctx, &ty, target, pkg)) {
-                    ReportErrorRange(pkg, TypeMismatchError, expr->pos,
+                    ReportError(pkg, TypeMismatchError, expr->pos,
                                 "Cannot assign %s to value of type %s", DescribeType(ty), DescribeType(lhsTypes[lhsIndex]));
-                    ReportNoteRange(pkg, expr->pos,
+                    ReportNote(pkg, expr->pos,
                                "Value comes from the %zu indexed result from call to %s", rhsIndex, DescribeExpr(expr));
                     // TODO: Use the language value comes from the %zu (st|nd|rd|th) result of the call to %s
                     // -vdka September 2018
@@ -2227,7 +2227,7 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
         }
 
         if (ctx->mode < ExprMode_Value) {
-            ReportErrorRange(pkg, NotAValueError, expr->pos,
+            ReportError(pkg, NotAValueError, expr->pos,
                         "Expected a value but got %s (type %s)", DescribeExpr(expr), DescribeType(type));
         } else {
             coerceType(expr, ctx, &type, lhsTypes[lhsIndex], pkg);
@@ -2240,7 +2240,7 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     ctx->desiredType = prevDesiredType;
 
     if (numLhs != values) {
-        ReportErrorRange(pkg, AssignmentCountMismatchError, stmt->pos,
+        ReportError(pkg, AssignmentCountMismatchError, stmt->pos,
                     "Left side has %zu values while right side has %zu values", ArrayLen(assign.lhs), ArrayLen(assign.rhs));
     }
 
@@ -2260,7 +2260,7 @@ void checkStmtReturn(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     // FIXME: What about returns that are tuples? We need a nice splat helper
 
     if (nExprs != nTypes) {
-        ReportErrorRange(pkg, WrongNumberOfReturnsError, stmt->pos,
+        ReportError(pkg, WrongNumberOfReturnsError, stmt->pos,
                     "Wrong number of return expressions, expected %zu, got %zu",
                     nTypes, ArrayLen(stmt->Return.exprs));
     }
@@ -2288,24 +2288,24 @@ void checkStmtGoto(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     ASSERT(stmt->kind == StmtKind_Goto);
 
     if (stmt->Goto.keyword == Keyword_break && !(ctx->loop || ctx->swtch)) {
-        ReportErrorRange(pkg, BreakNotPermittedError, stmt->pos,
+        ReportError(pkg, BreakNotPermittedError, stmt->pos,
                     "Break is not permitted outside of a switch or loop body");
         goto error;
     } else if (stmt->Goto.keyword == Keyword_continue && !ctx->loop) {
-        ReportErrorRange(pkg, ContinueNotPermittedError, stmt->pos,
+        ReportError(pkg, ContinueNotPermittedError, stmt->pos,
                     "Continue is not permitted outside of a loop body");
         goto error;
     } else if (stmt->Goto.keyword == Keyword_fallthrough) {
         if (stmt->Goto.target) {
-            ReportErrorRange(pkg, FallthroughWithTargetError, stmt->pos,
+            ReportError(pkg, FallthroughWithTargetError, stmt->pos,
                         "Fallthrough statements cannot provide a target to fall through too");
             goto error;
         } else if (!ctx->swtch) {
-            ReportErrorRange(pkg, FallthroughNotPermittedError, stmt->pos,
+            ReportError(pkg, FallthroughNotPermittedError, stmt->pos,
                         "Fallthrough is not permitted outside of a switch body");
             goto error;
         } else if (!ctx->nextCase) {
-            ReportErrorRange(pkg, FallthroughWithoutNextCaseError, stmt->pos,
+            ReportError(pkg, FallthroughWithoutNextCaseError, stmt->pos,
                         "Cannot fallthrough from here. There is no next case");
             goto error;
         }
@@ -2366,7 +2366,7 @@ void checkStmtIf(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
 
     Type *type = checkExpr(stmt->If.cond, &ifCtx, pkg);
     if (!coerceType(stmt->If.cond, &ifCtx, &type, BoolType, pkg)) {
-        ReportErrorRange(pkg, TypeMismatchError, stmt->If.cond->pos,
+        ReportError(pkg, TypeMismatchError, stmt->If.cond->pos,
                     "Expected type bool got type %s", DescribeType(type));
     }
     ifCtx.desiredType = ctx->desiredType;
@@ -2423,7 +2423,7 @@ void checkStmtForIn(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     } else if (isSlice(type)) {
         type = type->Slice.elementType;
     } else {
-        ReportErrorRange(pkg, CannotIterateError, stmt->ForIn.aggregate->pos,
+        ReportError(pkg, CannotIterateError, stmt->ForIn.aggregate->pos,
                     "Cannot iterate over %s (type %s) ", DescribeExpr(stmt->ForIn.aggregate), DescribeType(type));
         return;
     }
@@ -2453,7 +2453,7 @@ void checkStmtSwitch(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     if (stmt->Switch.match) {
         switchType = checkExpr(stmt->Switch.match, &switchCtx, pkg);
         if (!isNumericOrPointer(switchType) && !isBoolean(switchType)) {
-            ReportErrorRange(pkg, CannotSwitchError, stmt->Switch.match->pos,
+            ReportError(pkg, CannotSwitchError, stmt->Switch.match->pos,
                         "Cannot switch on value of type %s", DescribeType(switchType));
         }
     }
@@ -2465,12 +2465,12 @@ void checkStmtSwitch(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
         ForEach(switchCase->SwitchCase.matches, Expr *) {
             Type *type = checkExpr(it, &switchCtx, pkg);
             if (!coerceType(it, &switchCtx, &type, switchType, pkg)) {
-                ReportErrorRange(pkg, TypeMismatchError, it->pos, "Cannot convert %s to type %s",
+                ReportError(pkg, TypeMismatchError, it->pos, "Cannot convert %s to type %s",
                             DescribeType(type), DescribeType(switchType));
             }
         }
         if (!switchCase->SwitchCase.matches && i + 1 != ArrayLen(stmt->Switch.cases)) {
-            ReportErrorRange(pkg, DefaultSwitchCaseNotLastError, switchCase->pos,
+            ReportError(pkg, DefaultSwitchCaseNotLastError, switchCase->pos,
                         "The default switch case must be the final case");
         }
 

--- a/src/checker.c
+++ b/src/checker.c
@@ -3231,8 +3231,7 @@ void test_checkStmtReturn() {
 #define checkReturn(_CODE) \
 stmt = resetAndParseReturningLastStmt(_CODE); \
 checkStmtReturn(stmt, &ctx, &pkg); \
-RESET_CONTEXT(ctx); \
-ArrayClear(types)
+RESET_CONTEXT(ctx)
 
     Type *types[3] = {I64Type, I64Type, F64Type};
     Type type = {TypeKind_Tuple, .Tuple = {TypeFlag_None, types, 1}};

--- a/src/checker.c
+++ b/src/checker.c
@@ -579,7 +579,7 @@ void convertValue(Type *type, Type *target, Val *val) {
 
 b32 coerceTypeSilently(Expr *expr, CheckerContext *ctx, Type **type, Type *target, Package *pkg) {
     if (*type == InvalidType || target == InvalidType)
-        return false;
+        return true; // Prevent errors about type conversion to <invalid>
     if (TypesIdentical(*type, target))
         return true;
 

--- a/src/checker.c
+++ b/src/checker.c
@@ -1368,14 +1368,14 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     // Both lhs & rhs have this type.
     Type *type = lhs;
 
-    if (!binaryPredicates[expr->Binary.op](type)) {
+    if (!binaryPredicates[expr->Binary.op.kind](type)) {
         ReportError(pkg, InvalidBinaryOperationError, expr->Binary.pos,
                     "Operation '%s' undefined for type %s",
-                    DescribeTokenKind(expr->Binary.op), DescribeType(lhs));
+                    DescribeTokenKind(expr->Binary.op.kind), DescribeType(lhs));
         goto error;
     }
 
-    switch (expr->Binary.op) {
+    switch (expr->Binary.op.kind) {
         case TK_Eql:
         case TK_Neq:
         case TK_Leq:
@@ -1393,13 +1393,13 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
             break;
     }
 
-    if ((expr->Binary.op == TK_Div || expr->Binary.op == TK_Rem) && IsConstant(&rhsCtx) && rhsCtx.val.i64 == 0) {
+    if ((expr->Binary.op.kind == TK_Div || expr->Binary.op.kind == TK_Rem) && IsConstant(&rhsCtx) && rhsCtx.val.i64 == 0) {
         ReportError(pkg, DivisionByZeroError, expr->Binary.rhs->start, "Division by zero");
     }
 
     ctx->flags |= lhsCtx.flags & rhsCtx.flags & CheckerContextFlag_Constant;
     b32 isConstantNegative;
-    if (evalBinary(expr->Binary.op, type, lhsCtx.val, rhsCtx.val, ctx, &isConstantNegative)) {
+    if (evalBinary(expr->Binary.op.kind, type, lhsCtx.val, rhsCtx.val, ctx, &isConstantNegative)) {
         changeTypeOrRecordCoercionIfNeeded(&type, expr, ctx, isConstantNegative, pkg);
     }
     storeInfoBasicExpr(pkg, expr, type, ctx);

--- a/src/checker.c
+++ b/src/checker.c
@@ -169,8 +169,8 @@ CheckerInfo *CheckerInfoForDecl(Package *pkg, Decl *decl) {
 b32 declareSymbol(Package *pkg, Scope *scope, const char *name, Symbol **symbol, Decl *decl) {
     Symbol *old = Lookup(scope, name);
     if (old) {
-        ReportError(pkg, RedefinitionError, decl->start, "Duplicate definition of symbol %s", name);
-        ReportNote(pkg, old->decl->start, "Previous definition of %s", name);
+        ReportErrorRange(pkg, RedefinitionError, decl->pos, "Duplicate definition of symbol %s", name);
+        ReportNoteRange(pkg, old->decl->pos, "Previous definition of %s", name);
         if (symbol) *symbol = old;
         return true;
     }
@@ -203,9 +203,9 @@ Symbol *declareLabelSymbol(Package *pkg, Scope *scope, const char *name) {
     return symbol;
 }
 
-b32 expectType(Package *pkg, Type *type, CheckerContext *ctx, Position pos) {
+b32 expectType(Package *pkg, Type *type, CheckerContext *ctx, SourceRange pos) {
     if (ctx->mode != ExprMode_Type && ctx->mode != ExprMode_Invalid) {
-        ReportError(pkg, NotATypeError, pos, "%s cannot be used as a type", DescribeTypeKind(type->kind));
+        ReportErrorRange(pkg, NotATypeError, pos, "%s cannot be used as a type", DescribeTypeKind(type->kind));
     }
     return true;
 }
@@ -600,7 +600,7 @@ b32 coerceType(Expr *expr, CheckerContext *ctx, Type **type, Type *target, Packa
 
     b32 success = coerceTypeSilently(expr, ctx, type, target, pkg);
     if (!success) {
-        ReportError(pkg, InvalidConversionError, expr->start,
+        ReportErrorRange(pkg, InvalidConversionError, expr->pos,
                     "Cannot convert %s to type %s", DescribeExpr(expr), DescribeType(target));
         *type = InvalidType;
     }
@@ -689,7 +689,7 @@ Type *checkExprIdent(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Expr_Ident ident = expr->Ident;
     Symbol *symbol = Lookup(ctx->scope, ident.name);
     if (!symbol) {
-        ReportError(pkg, UndefinedIdentError, expr->start, "Use of undefined identifier '%s'", ident.name);
+        ReportErrorRange(pkg, UndefinedIdentError, expr->pos, "Use of undefined identifier '%s'", ident.name);
         ctx->mode = ExprMode_Invalid;
         return InvalidType;
     }
@@ -707,7 +707,7 @@ Type *checkExprIdent(Expr *expr, CheckerContext *ctx, Package *pkg) {
         case SymbolState_Resolving:
             // TODO: For cyclic types we need a ctx->hasIndirection to check and see if
             // We have a cyclic reference error.
-            ReportError(pkg, ReferenceToDeclarationError, expr->start,
+            ReportErrorRange(pkg, ReferenceToDeclarationError, expr->pos,
                         "Declaration initial value refers to itself");
             break;
 
@@ -766,10 +766,10 @@ Type *checkExprLitInt(Expr *expr, CheckerContext *ctx, Package *pkg) {
             ctx->val.u64 = lit.val;
 
             if (lit.val > MaxValueForIntOrPointerType(ctx->desiredType)) {
-                ReportError(pkg, InvalidConversionError, expr->start,
+                ReportErrorRange(pkg, InvalidConversionError, expr->pos,
                             "Cannot coerce value '%s' to type %s as loss of information would occur",
                             DescribeExpr(expr), DescribeType(ctx->desiredType));
-                ReportNote(pkg, expr->start, "If you wish for this overflow to occur add an explicit cast");
+                ReportNoteRange(pkg, expr->pos, "If you wish for this overflow to occur add an explicit cast");
             }
         } else if (IsFloat(ctx->desiredType)) {
             ctx->val.f64 = (f64)lit.val;
@@ -803,7 +803,7 @@ Type *checkExprLitFloat(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 ctx->val.f64 = lit.val;
             }
         } else {
-            ReportError(pkg, InvalidConversionError, expr->start,
+            ReportErrorRange(pkg, InvalidConversionError, expr->pos,
                         "Unable to coerce %s to expected type %s",
                         DescribeExpr(expr), DescribeType(ctx->desiredType));
             // TODO: Check if it's possible through casting and add note that you can cast to make the conversion occur @ErrorQuality
@@ -828,7 +828,7 @@ error:
 Type *checkExprLitNil(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_LitNil);
     if (ctx->desiredType && !isNilable(ctx->desiredType)) {
-        ReportError(pkg, NotNilableError, expr->start,
+        ReportErrorRange(pkg, NotNilableError, expr->pos,
                     "'nil' is not convertable to '%s'", DescribeType(ctx->desiredType));
         goto error;
     }
@@ -864,7 +864,7 @@ Type *checkExprLitString(Expr *expr, CheckerContext *ctx, Package *pkg) {
 Type *checkExprTypeVariadic(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_TypeVariadic);
     Type *type = checkExpr(expr->TypeVariadic.type, ctx, pkg);
-    if (!expectType(pkg, type, ctx, expr->TypeVariadic.type->start)) goto error;
+    if (!expectType(pkg, type, ctx, expr->TypeVariadic.type->pos)) goto error;
     TypeFlag flags = expr->TypeVariadic.flags & TypeVariadicFlag_CVargs ? TypeFlag_CVargs : TypeFlag_None;
     type = NewTypeSlice(flags | TypeFlag_Variadic, type);
     storeInfoBasicExpr(pkg, expr, type, ctx);
@@ -892,7 +892,7 @@ Type *checkExprTypeFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
         if (paramCtx.mode == ExprMode_Invalid) goto error;
         if (paramCtx.mode == ExprMode_Unresolved) goto unresolved;
 
-        if (!expectType(pkg, type, &paramCtx, func.params[i]->start)) isInvalid = true;
+        if (!expectType(pkg, type, &paramCtx, func.params[i]->pos)) isInvalid = true;
 
         flags |= type->Flags & TypeFlag_Variadic;
         flags |= type->Flags & TypeFlag_CVargs;
@@ -908,7 +908,7 @@ Type *checkExprTypeFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
         if (paramCtx.mode == ExprMode_Invalid) goto error;
         if (paramCtx.mode == ExprMode_Unresolved) goto unresolved;
 
-        if (!expectType(pkg, type, &paramCtx, it->start)) {
+        if (!expectType(pkg, type, &paramCtx, it->pos)) {
             isInvalid = true;
         }
         ArrayPush(results, type);
@@ -918,7 +918,7 @@ Type *checkExprTypeFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     if (isVoid) {
         if (ArrayLen(func.result) > 1) {
-            ReportError(pkg, InvalidUseOfVoidError, expr->start,
+            ReportErrorRange(pkg, InvalidUseOfVoidError, expr->pos,
                         "Void must be a functions only return type");
         } else {
             ArrayFree(results);
@@ -961,7 +961,7 @@ Type *checkExprLitFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
     // FIXME: We need to extract and pass on desired types parameters & results
     ForEach(func.type->TypeFunction.params, Expr_KeyValue *) {
         if (!it->key || it->key->kind != ExprKind_Ident) {
-            ReportError(pkg, ParamNameMissingError, it->start, "Parameters for a function literal must be named");
+            ReportErrorRange(pkg, ParamNameMissingError, it->pos, "Parameters for a function literal must be named");
             continue;
         }
 
@@ -970,7 +970,7 @@ Type *checkExprLitFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
         symbol->kind = SymbolKind_Variable;
 
         Type *type = checkExpr(it->value, &paramCtx, pkg);
-        if (!expectType(pkg, type, &paramCtx, it->value->start)) continue;
+        if (!expectType(pkg, type, &paramCtx, it->value->pos)) continue;
         markSymbolResolved(symbol, type);
 
         // TODO: Support unnamed parameters ($0, $1, $2)
@@ -984,7 +984,7 @@ Type *checkExprLitFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
     bool isVoid = false;
     ForEach(func.type->TypeFunction.result, Expr *) {
         Type *type = checkExpr(it, &paramCtx, pkg);
-        if (!expectType(pkg, type, &paramCtx, it->start)) continue;
+        if (!expectType(pkg, type, &paramCtx, it->pos)) continue;
         ArrayPush(results, type);
         isVoid |= type == VoidType;
     }
@@ -1001,7 +1001,7 @@ Type *checkExprLitFunction(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     if (isVoid) {
         if (ArrayLen(func.type->TypeFunction.result) > 1) {
-            ReportError(pkg, InvalidUseOfVoidError, expr->LitFunction.type->start,
+            ReportErrorRange(pkg, InvalidUseOfVoidError, expr->LitFunction.type->pos,
                         "Void must be a functions only return type");
         } else {
             ArrayFree(results);
@@ -1034,7 +1034,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (expr->LitCompound.type) {
         type = checkExpr(expr->LitCompound.type, ctx, pkg);
         if (ctx->mode == ExprMode_Unresolved) return NULL;
-        expectType(pkg, type, ctx, expr->LitCompound.type->start);
+        expectType(pkg, type, ctx, expr->LitCompound.type->pos);
     }
 
     size_t maxIndex = 0;
@@ -1046,7 +1046,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 case TypeKind_Array:
                 case TypeKind_Slice:
                     if (!(it->flags & KeyValueFlag_Index)) {
-                        ReportError(pkg, ArrayCompoundMissingIndexError, it->key->start,
+                        ReportErrorRange(pkg, ArrayCompoundMissingIndexError, it->key->pos,
                                     "Array or Slice key should be surrounded in `[]`");
                         goto checkValue;
                     }
@@ -1068,7 +1068,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
                     // Allow 0 length arrays to be indexed freely
                     if (type->kind == TypeKind_Array && type->Array.length && type->Array.length <= currentIndex) {
-                        ReportError(pkg, TODOError, it->value->start,
+                        ReportErrorRange(pkg, TODOError, it->value->pos,
                                     "Array index %llu is beyond the max index of %llu for type %s",
                                     currentIndex, type->Array.length - 1, DescribeType(type));
                     }
@@ -1079,12 +1079,12 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
                 case TypeKind_Struct:
                     if (it->flags & KeyValueFlag_Index) {
-                        ReportError(pkg, TODOError, it->key->start, "Cannot initalize struct members using index");
+                        ReportErrorRange(pkg, TODOError, it->key->pos, "Cannot initalize struct members using index");
                         goto checkValue;
                     }
 
                     if (it->key->kind != ExprKind_Ident) {
-                        ReportError(pkg, TODOError, it->key->start,
+                        ReportErrorRange(pkg, TODOError, it->key->pos,
                                     "Expected identifier for field name for type %s", DescribeType(type));
                         goto checkValue;
                     }
@@ -1093,7 +1093,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
                     StructFieldLookupResult result = StructFieldLookup(type->Struct, fieldName);
                     if (!result.field) {
-                        ReportError(pkg, TODOError, it->key->start,
+                        ReportErrorRange(pkg, TODOError, it->key->pos,
                                     "Type %s has no field named %s", DescribeType(type), fieldName);
                     }
 
@@ -1111,7 +1111,7 @@ Type *checkExprLitCompound(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 case TypeKind_Array:
                     // Allow 0 length arrays to be indexed freely
                     if (type->Array.length && type->Array.length <= currentIndex) {
-                        ReportError(pkg, TODOError, it->value->start,
+                        ReportErrorRange(pkg, TODOError, it->value->pos,
                                     "Array index %llu is beyond the max index of %llu for type %s",
                                     currentIndex, type->Array.length - 1, DescribeType(type));
                     }
@@ -1156,13 +1156,13 @@ Type *checkExprTypePointer(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Invalid) goto error;
     if (ctx->mode == ExprMode_Unresolved) return NULL;
 
-    expectType(pkg, type, ctx, expr->TypePointer.type->start);
+    expectType(pkg, type, ctx, expr->TypePointer.type->pos);
     if (ctx->mode != ExprMode_Type) {
-        ReportError(pkg, InvalidPointeeTypeError, expr->start,
+        ReportErrorRange(pkg, InvalidPointeeTypeError, expr->pos,
                     "'%s' is not a valid pointee type", DescribeType(type));
         goto error;
     } else if (type == VoidType) {
-        ReportError(pkg, InvalidPointeeTypeError, expr->TypePointer.type->start,
+        ReportErrorRange(pkg, InvalidPointeeTypeError, expr->TypePointer.type->pos,
                     "Kai does not use void * for raw pointers instead use rawptr");
     }
 
@@ -1187,11 +1187,11 @@ Type *checkExprTypeArray(Expr *expr, CheckerContext *ctx, Package *pkg) {
     u64 length = ctx->val.u64;
 
     Type *type = checkExpr(expr->TypeArray.type, ctx, pkg);
-    expectType(pkg, type, ctx, expr->TypeArray.type->start);
+    expectType(pkg, type, ctx, expr->TypeArray.type->pos);
     if (ctx->mode != ExprMode_Type) {
         goto error;
     } else if (type->Width == 0) {
-        ReportError(pkg, ZeroWidthArrayElementError, expr->TypeArray.type->start,
+        ReportErrorRange(pkg, ZeroWidthArrayElementError, expr->TypeArray.type->pos,
                     "Arrays of zero width elements are not permitted");
     }
 
@@ -1205,9 +1205,9 @@ Type *checkExprTypeArray(Expr *expr, CheckerContext *ctx, Package *pkg) {
         length = ctx->val.u64;
 
         if (!(ctx->flags & CheckerContextFlag_Constant)) {
-            ReportError(pkg, NonConstantArrayLengthError, expr->TypeArray.length->start,
+            ReportErrorRange(pkg, NonConstantArrayLengthError, expr->TypeArray.length->pos,
                         "An arrays length must be a constant value");
-            ReportNote(pkg, expr->start, "To infer a length for the array type from the context use `..` as the length");
+            ReportNoteRange(pkg, expr->pos, "To infer a length for the array type from the context use `..` as the length");
         }
     } else {
         // NOTE: We need someway to pass down the length from the caller because we cannot create and later on update
@@ -1239,11 +1239,11 @@ error:
 Type *checkExprTypeSlice(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_TypeSlice);
     Type *type = checkExpr(expr->TypeSlice.type, ctx, pkg);
-    expectType(pkg, type, ctx, expr->TypeSlice.type->start);
+    expectType(pkg, type, ctx, expr->TypeSlice.type->pos);
     if (ctx->mode != ExprMode_Type) {
         goto error;
     } if (type->Width == 0) {
-        ReportError(pkg, ZeroWidthSliceElementError, expr->TypeSlice.type->start,
+        ReportErrorRange(pkg, ZeroWidthSliceElementError, expr->TypeSlice.type->pos,
                     "Slices of zero width elements are not permitted");
     }
 
@@ -1311,7 +1311,7 @@ Type *checkExprUnary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     switch (expr->Unary.op) {
         case TK_And:
             if (ctx->mode < ExprMode_Addressable) {
-                ReportError(pkg, AddressOfNonAddressableError, expr->start,
+                ReportErrorRange(pkg, AddressOfNonAddressableError, expr->pos,
                             "Cannot take address of %s", DescribeExpr(expr->Unary.expr));
                 goto error;
             }
@@ -1320,7 +1320,7 @@ Type *checkExprUnary(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
         default:
             if (!unaryPredicates[expr->Unary.op](type)) {
-                ReportError(pkg, InvalidUnaryOperationError, expr->start,
+                ReportErrorRange(pkg, InvalidUnaryOperationError, expr->pos,
                             "Operation '%s' undefined for %s",
                             DescribeTokenKind(expr->Unary.op), DescribeExpr(expr->Unary.expr));
                 goto error;
@@ -1358,10 +1358,10 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     // TODO: clean this up
     if (!(coerceTypeSilently(expr->Binary.lhs, &lhsCtx, &lhs, rhs, pkg) ||
           coerceTypeSilently(expr->Binary.rhs, &rhsCtx, &rhs, lhs, pkg))) {
-        ReportError(pkg, TypeMismatchError, expr->start,
+        ReportErrorRange(pkg, TypeMismatchError, expr->pos,
                     "No conversion possible to make %s and %s Identical types",
                     DescribeExpr(expr->Binary.lhs), DescribeExpr(expr->Binary.rhs));
-        ReportNote(pkg, expr->start, "An explicit cast may be required");
+        ReportNoteRange(pkg, expr->pos, "An explicit cast may be required");
         goto error;
     }
 
@@ -1369,7 +1369,7 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Type *type = lhs;
 
     if (!binaryPredicates[expr->Binary.op.kind](type)) {
-        ReportError(pkg, InvalidBinaryOperationError, expr->Binary.op.pos,
+        ReportErrorPosition(pkg, InvalidBinaryOperationError, expr->Binary.op.pos,
                     "Operation '%s' undefined for type %s",
                     DescribeTokenKind(expr->Binary.op.kind), DescribeType(lhs));
         goto error;
@@ -1394,7 +1394,7 @@ Type *checkExprBinary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     }
 
     if ((expr->Binary.op.kind == TK_Div || expr->Binary.op.kind == TK_Rem) && IsConstant(&rhsCtx) && rhsCtx.val.i64 == 0) {
-        ReportError(pkg, DivisionByZeroError, expr->Binary.rhs->start, "Division by zero");
+        ReportErrorRange(pkg, DivisionByZeroError, expr->Binary.rhs->pos, "Division by zero");
     }
 
     ctx->flags |= lhsCtx.flags & rhsCtx.flags & CheckerContextFlag_Constant;
@@ -1429,7 +1429,7 @@ Type *checkExprTernary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (failCtx.mode == ExprMode_Unresolved)
 
     if (condCtx.mode != ExprMode_Invalid && !isBoolean(cond) && !isNumericOrPointer(cond)) {
-        ReportError(pkg, BadConditionError, expr->start,
+        ReportErrorRange(pkg, BadConditionError, expr->pos,
                     "Expected a numeric or pointer type to act as a condition in the ternary expression");
         goto error;
     }
@@ -1444,7 +1444,7 @@ Type *checkExprTernary(Expr *expr, CheckerContext *ctx, Package *pkg) {
     } else {
         // NOTE: If we coerce the type before doing handling constant evaluation, we lose signedness information.
         if (!coerceType(expr->Ternary.fail, &failCtx, &fail, pass, pkg)) {
-            ReportError(pkg, TypeMismatchError, expr->Ternary.fail->start,
+            ReportErrorRange(pkg, TypeMismatchError, expr->Ternary.fail->pos,
                         "Expected type %s got type %s", DescribeType(pass ? pass : cond), DescribeType(fail));
             goto error;
         }
@@ -1464,7 +1464,7 @@ Type *checkExprLocationDirective(Expr *expr, CheckerContext *ctx, Package *pkg) 
     ctx->flags |= CheckerContextFlag_Constant;
     if (expr->LocationDirective.name == internLine) {
         type = U32Type;
-        ctx->val.u32 = expr->start.line;
+        ctx->val.u32 = expr->pos.line;
     } else if (expr->LocationDirective.name == internFile) {
         // TODO: @Strings @Builtins
     } else if (expr->LocationDirective.name == internLocation) {
@@ -1482,7 +1482,7 @@ Type *checkExprCast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     Type *type = checkExpr(expr->Cast.type, &targetCtx, pkg);
 
     if (targetCtx.mode != ExprMode_Type) {
-        ReportError(pkg, NotATypeError, expr->start,
+        ReportErrorRange(pkg, NotATypeError, expr->pos,
                     "Cannot cast to non type %s", DescribeExpr(expr->Cast.type));
         goto error;
     }
@@ -1494,7 +1494,7 @@ Type *checkExprCast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Invalid) goto error;
 
     if (!cast(exprType, type, ctx)) {
-        ReportError(pkg, InvalidConversionError, expr->start,
+        ReportErrorRange(pkg, InvalidConversionError, expr->pos,
                     "Unable to cast type %s to type %s", DescribeType(exprType), DescribeType(type));
         goto error;
     }
@@ -1515,7 +1515,7 @@ error:
 Type *checkExprAutocast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     ASSERT(expr->kind == ExprKind_Autocast);
     if (!ctx->desiredType) {
-        ReportError(pkg, AutocastExpectsDesiredTypeError, expr->start,
+        ReportErrorRange(pkg, AutocastExpectsDesiredTypeError, expr->pos,
                     "Autocast expression requires a contextual type to convert to");
         goto error;
     }
@@ -1524,7 +1524,7 @@ Type *checkExprAutocast(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Invalid) goto error;
 
     if (!cast(type, ctx->desiredType, ctx)) {
-        ReportError(pkg, InvalidConversionError, expr->Autocast.expr->start,
+        ReportErrorRange(pkg, InvalidConversionError, expr->Autocast.expr->pos,
                     "Cannot convert expression of type %s to type %s",
                     DescribeType(type), DescribeType(ctx->desiredType));
         goto error;
@@ -1548,7 +1548,7 @@ Type *checkExprSubscript(Expr *expr, CheckerContext *ctx, Package *pkg) {
     if (indexCtx.mode == ExprMode_Invalid) goto error;
 
     if (!IsInteger(index)) {
-        ReportError(pkg, InvalidSubscriptIndexTypeError, expr->Subscript.index->start,
+        ReportErrorRange(pkg, InvalidSubscriptIndexTypeError, expr->Subscript.index->pos,
                     "Cannot subscript with non-integer type '%s'",
                     DescribeType(index));
         goto error;
@@ -1563,7 +1563,7 @@ Type *checkExprSubscript(Expr *expr, CheckerContext *ctx, Package *pkg) {
             i64 i = indexCtx.val.i64;
             if (i < 0 || (u64)i >= recv->Array.length) {
                 const char *message = i < 0 ? "before the start" : "after the end of";
-                ReportError(pkg, OutOfBoundsError, expr->Subscript.index->start,
+                ReportErrorRange(pkg, OutOfBoundsError, expr->Subscript.index->pos,
                             "Index %d is %s of the array (%lu elements)",
                             i, message, recv->Array.length);
                 goto error;
@@ -1581,7 +1581,7 @@ Type *checkExprSubscript(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
     default:
         if (recv != InvalidType) {
-            ReportError(pkg, UnsupportedSubscriptError, expr->Subscript.expr->start,
+            ReportErrorRange(pkg, UnsupportedSubscriptError, expr->Subscript.expr->pos,
                         "Unable to subscript type '%s'",
                         DescribeType(recv));
         }
@@ -1613,7 +1613,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
         case TypeKind_Struct: {
             StructFieldLookupResult result = StructFieldLookup(base->Struct, expr->Selector.name);
             if (!result.field) {
-                ReportError(pkg, TODOError, expr->Selector.start, "Struct %s has no member %s",
+                ReportErrorRange(pkg, TODOError, expr->Selector.pos, "Struct %s has no member %s",
                             DescribeType(base), expr->Selector.name);
                 goto error;
             }
@@ -1637,7 +1637,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
 
             Symbol *symbol = Lookup(import->scope, expr->Selector.name);
             if (!symbol) {
-                ReportError(pkg, TODOError, expr->Selector.start, "File %s has no member %s",
+                ReportErrorRange(pkg, TODOError, expr->Selector.pos, "File %s has no member %s",
                             DescribeExpr(expr->Selector.expr), expr->Selector.name);
                 goto error;
             }
@@ -1649,7 +1649,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
                 case SymbolState_Resolving:
                     // TODO: For cyclic types we need a ctx->hasIndirection to check and see if
                     // We have a cyclic reference error.
-                    ReportError(pkg, ReferenceToDeclarationError, expr->start,
+                    ReportErrorRange(pkg, ReferenceToDeclarationError, expr->pos,
                                 "Declaration initial value refers to itself");
                     break;
                 case SymbolState_Resolved:
@@ -1664,7 +1664,7 @@ Type *checkExprSelector(Expr *expr, CheckerContext *ctx, Package *pkg) {
         }
 
         default: {
-            ReportError(pkg, TODOError, expr->start, "%s has no member '%s'", DescribeExpr(expr->Selector.expr), expr->Selector.name);
+            ReportErrorRange(pkg, TODOError, expr->pos, "%s has no member '%s'", DescribeExpr(expr->Selector.expr), expr->Selector.name);
             goto error;
         }
     }
@@ -1691,17 +1691,17 @@ Type *checkExprCall(Expr *expr, CheckerContext *ctx, Package *pkg) {
         // This is a cast not a call
 
         if (ArrayLen(expr->Call.args) < 1) {
-            ReportError(pkg, CastArgumentCountError, expr->start,
+            ReportErrorRange(pkg, CastArgumentCountError, expr->pos,
                         "Missing argument in cast to %s", DescribeType(calleeType));
             goto error;
         } else if (ArrayLen(expr->Call.args) > 1) {
-            ReportError(pkg, CastArgumentCountError, expr->start,
+            ReportErrorRange(pkg, CastArgumentCountError, expr->pos,
                         "Too many arguments in cast to %s", DescribeType(calleeType));
             goto error;
         }
 
         expr->kind = ExprKind_Cast;
-        Expr_Cast cast = { .start = expr->start, .type = expr->Call.expr, .expr = expr->Call.args[0]->value };
+        Expr_Cast cast = {expr->pos, .type = expr->Call.expr, .expr = expr->Call.args[0]->value };
         expr->Cast = cast;
         return checkExprCast(expr, ctx, pkg);
     }
@@ -1715,7 +1715,7 @@ Type *checkExprCall(Expr *expr, CheckerContext *ctx, Package *pkg) {
         Expr_KeyValue *arg = expr->Call.args[i];
 
         if (i >= nParams && !(calleeType->Function.Flags & TypeFlag_Variadic)) {
-            ReportError(pkg, TODOError, arg->start,
+            ReportErrorRange(pkg, TODOError, arg->pos,
                         "Too many arguments in call to '%s'", DescribeExpr(expr->Call.expr));
             break;
         }
@@ -1863,7 +1863,7 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
     Decl_Constant constant = decl->Constant;
 
     if (ArrayLen(constant.names) != 1) {
-        ReportError(pkg, MultipleConstantDeclError, constant.start,
+        ReportErrorRange(pkg, MultipleConstantDeclError, constant.pos,
             "Constant declarations must declare at most one item");
 
         ForEach (constant.names, Expr_Ident *) {
@@ -1874,7 +1874,7 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
     }
 
     if (ArrayLen(constant.values) > 1) {
-        ReportError(pkg, ArityMismatchError, constant.start,
+        ReportErrorRange(pkg, ArityMismatchError, constant.pos,
                     "Constant declarations only allow for a single value, but got %zu", ArrayLen(constant.values));
         return;
     }
@@ -1885,7 +1885,7 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
         expectedType = checkExpr(constant.type, ctx, pkg);
         if (ctx->mode == ExprMode_Unresolved) return;
 
-        expectType(pkg, expectedType, ctx, constant.type->start);
+        expectType(pkg, expectedType, ctx, constant.type->pos);
     }
 
     Expr_Ident *ident = constant.names[0];
@@ -1907,7 +1907,7 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
             Type *type = checkExprTypeFunction(func.type, ctx, pkg);
             if (ctx->mode == ExprMode_Unresolved) return;
 
-            expectType(pkg, type, ctx, func.type->start);
+            expectType(pkg, type, ctx, func.type->pos);
 
             markSymbolResolved(symbol, type);
             symbol->kind = SymbolKind_Constant;
@@ -1936,14 +1936,14 @@ void checkDeclConstant(Decl *decl, CheckerContext *ctx, Package *pkg) {
     if (exprCtx.mode < ExprMode_Type || (((exprCtx.flags & CheckerContextFlag_Constant) == 0) && (exprCtx.mode != ExprMode_Type))) {
         // The above checks that the expression is constant
         // TODO: Simplify the above ... possibly by shifting around the ExprMode orders so that Addressable is lesser then Value.
-        ReportError(pkg, NotAValueError, value->start,
+        ReportErrorRange(pkg, NotAValueError, value->pos,
                     "Expected a type or constant value but got %s (type %s)", DescribeExpr(value), DescribeType(type));
     }
 
     symbol->val = exprCtx.val;
 
     if (expectedType && !coerceType(value, &exprCtx, &type, expectedType, pkg)) {
-        ReportError(pkg, InvalidConversionError, value->start,
+        ReportErrorRange(pkg, InvalidConversionError, value->pos,
                     "Unable to convert type %s to expected type type %s", DescribeType(type), DescribeType(expectedType));
         markSymbolInvalid(symbol);
         return;
@@ -1971,7 +1971,7 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
         expectedType = checkExpr(var.type, ctx, pkg);
         if (ctx->mode == ExprMode_Unresolved) return;
 
-        expectType(pkg, expectedType, ctx, var.type->start);
+        expectType(pkg, expectedType, ctx, var.type->pos);
     }
 
     u32 numLhs = (u32) ArrayLen(var.names);
@@ -2004,9 +2004,9 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
         }
 
         if (expectedType->kind == TypeKind_Function) {
-            ReportError(pkg, UninitFunctionTypeError, var.type->start,
+            ReportErrorRange(pkg, UninitFunctionTypeError, var.type->pos,
                 "Variables of a function type must be initialized");
-            ReportNote(pkg, var.type->start,
+            ReportNoteRange(pkg, var.type->pos,
                        "If you want an uninitialized function pointer use *%s instead", DescribeType(expectedType));
         }
     } else {
@@ -2037,10 +2037,10 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
                     }
 
                     if (expectedType && !coerceTypeSilently(expr, &exprCtx, &ty, expectedType, pkg)) {
-                        ReportError(pkg, TypeMismatchError, expr->start,
+                        ReportErrorRange(pkg, TypeMismatchError, expr->pos,
                                     "Cannot convert %s to expected type %s",
                                     DescribeType(ty), DescribeType(expectedType));
-                        ReportNote(pkg, expr->start,
+                        ReportNoteRange(pkg, expr->pos,
                                    "Value comes from the %zu indexed result from call to %s",
                                    rhsIndex, DescribeExpr(expr));
                         // TODO: Use the language value comes from the %zu (st|nd|rd|th) result of the call to %s
@@ -2061,7 +2061,7 @@ void checkDeclVariable(Decl *decl, CheckerContext *ctx, Package *pkg) {
             }
 
             if (exprCtx.mode < ExprMode_Value) {
-                ReportError(pkg, NotAValueError, expr->start,
+                ReportErrorRange(pkg, NotAValueError, expr->pos,
                             "Expected a value but got %s (type %s)", DescribeExpr(expr), DescribeType(type));
             } else if (expectedType) {
                 coerceType(expr, &exprCtx, &type, expectedType, pkg);
@@ -2089,7 +2089,7 @@ void checkDeclForeign(Decl *decl, CheckerContext *ctx, Package *pkg) {
     Type *type = checkExpr(decl->Foreign.type, ctx, pkg);
     if (ctx->mode == ExprMode_Unresolved) return;
 
-    expectType(pkg, type, ctx, decl->Foreign.type->start);
+    expectType(pkg, type, ctx, decl->Foreign.type->pos);
 
     Symbol *symbol;
     if (ctx->scope == pkg->scope) {
@@ -2114,7 +2114,7 @@ void checkDeclForeignBlock(Decl *decl, CheckerContext *ctx, Package *pkg) {
         Type *type = checkExpr(it.type, ctx, pkg);
         if (ctx->mode == ExprMode_Unresolved) return;
 
-        expectType(pkg, type, ctx, it.type->start);
+        expectType(pkg, type, ctx, it.type->pos);
 
         Symbol *symbol = it.symbol;
         symbol->externalName = it.linkname;
@@ -2131,7 +2131,7 @@ void checkDeclImport(Decl *decl, CheckerContext *ctx, Package *pkg) {
     if (ctx->mode == ExprMode_Unresolved) return;
 
     if (!TypesIdentical(type, StringType) || !IsConstant(ctx)) {
-        ReportError(pkg, TODOError, decl->start,
+        ReportErrorRange(pkg, TODOError, decl->pos,
                     "Could not resolve path %s to string constant", DescribeExpr(decl->Import.path));
         goto error;
     }
@@ -2172,7 +2172,7 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
         } else {
             ArrayPush(lhsTypes, type);
             if (ctx->mode < ExprMode_Addressable && ctx->mode != ExprMode_Invalid) {
-                ReportError(pkg, ValueNotAssignableError, it->start,
+                ReportErrorRange(pkg, ValueNotAssignableError, it->pos,
                             "Cannot assign to value %s of type %s", DescribeExpr(it), DescribeType(type));
             }
         }
@@ -2208,9 +2208,9 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
                 CheckerInfoForExpr(pkg, assign.lhs[lhsIndex])->coerce = conversion(ty, target);
 
                 if (!coerceTypeSilently(expr, ctx, &ty, target, pkg)) {
-                    ReportError(pkg, TypeMismatchError, expr->start,
+                    ReportErrorRange(pkg, TypeMismatchError, expr->pos,
                                 "Cannot assign %s to value of type %s", DescribeType(ty), DescribeType(lhsTypes[lhsIndex]));
-                    ReportNote(pkg, expr->start,
+                    ReportNoteRange(pkg, expr->pos,
                                "Value comes from the %zu indexed result from call to %s", rhsIndex, DescribeExpr(expr));
                     // TODO: Use the language value comes from the %zu (st|nd|rd|th) result of the call to %s
                     // -vdka September 2018
@@ -2227,7 +2227,7 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
         }
 
         if (ctx->mode < ExprMode_Value) {
-            ReportError(pkg, NotAValueError, expr->start,
+            ReportErrorRange(pkg, NotAValueError, expr->pos,
                         "Expected a value but got %s (type %s)", DescribeExpr(expr), DescribeType(type));
         } else {
             coerceType(expr, ctx, &type, lhsTypes[lhsIndex], pkg);
@@ -2240,7 +2240,7 @@ void checkStmtAssign(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     ctx->desiredType = prevDesiredType;
 
     if (numLhs != values) {
-        ReportError(pkg, AssignmentCountMismatchError, stmt->start,
+        ReportErrorRange(pkg, AssignmentCountMismatchError, stmt->pos,
                     "Left side has %zu values while right side has %zu values", ArrayLen(assign.lhs), ArrayLen(assign.rhs));
     }
 
@@ -2260,7 +2260,7 @@ void checkStmtReturn(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     // FIXME: What about returns that are tuples? We need a nice splat helper
 
     if (nExprs != nTypes) {
-        ReportError(pkg, WrongNumberOfReturnsError, stmt->start,
+        ReportErrorRange(pkg, WrongNumberOfReturnsError, stmt->pos,
                     "Wrong number of return expressions, expected %zu, got %zu",
                     nTypes, ArrayLen(stmt->Return.exprs));
     }
@@ -2288,24 +2288,24 @@ void checkStmtGoto(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     ASSERT(stmt->kind == StmtKind_Goto);
 
     if (stmt->Goto.keyword == Keyword_break && !(ctx->loop || ctx->swtch)) {
-        ReportError(pkg, BreakNotPermittedError, stmt->start,
+        ReportErrorRange(pkg, BreakNotPermittedError, stmt->pos,
                     "Break is not permitted outside of a switch or loop body");
         goto error;
     } else if (stmt->Goto.keyword == Keyword_continue && !ctx->loop) {
-        ReportError(pkg, ContinueNotPermittedError, stmt->start,
+        ReportErrorRange(pkg, ContinueNotPermittedError, stmt->pos,
                     "Continue is not permitted outside of a loop body");
         goto error;
     } else if (stmt->Goto.keyword == Keyword_fallthrough) {
         if (stmt->Goto.target) {
-            ReportError(pkg, FallthroughWithTargetError, stmt->start,
+            ReportErrorRange(pkg, FallthroughWithTargetError, stmt->pos,
                         "Fallthrough statements cannot provide a target to fall through too");
             goto error;
         } else if (!ctx->swtch) {
-            ReportError(pkg, FallthroughNotPermittedError, stmt->start,
+            ReportErrorRange(pkg, FallthroughNotPermittedError, stmt->pos,
                         "Fallthrough is not permitted outside of a switch body");
             goto error;
         } else if (!ctx->nextCase) {
-            ReportError(pkg, FallthroughWithoutNextCaseError, stmt->start,
+            ReportErrorRange(pkg, FallthroughWithoutNextCaseError, stmt->pos,
                         "Cannot fallthrough from here. There is no next case");
             goto error;
         }
@@ -2366,7 +2366,7 @@ void checkStmtIf(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
 
     Type *type = checkExpr(stmt->If.cond, &ifCtx, pkg);
     if (!coerceType(stmt->If.cond, &ifCtx, &type, BoolType, pkg)) {
-        ReportError(pkg, TypeMismatchError, stmt->If.cond->start,
+        ReportErrorRange(pkg, TypeMismatchError, stmt->If.cond->pos,
                     "Expected type bool got type %s", DescribeType(type));
     }
     ifCtx.desiredType = ctx->desiredType;
@@ -2423,7 +2423,7 @@ void checkStmtForIn(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     } else if (isSlice(type)) {
         type = type->Slice.elementType;
     } else {
-        ReportError(pkg, CannotIterateError, stmt->ForIn.aggregate->start,
+        ReportErrorRange(pkg, CannotIterateError, stmt->ForIn.aggregate->pos,
                     "Cannot iterate over %s (type %s) ", DescribeExpr(stmt->ForIn.aggregate), DescribeType(type));
         return;
     }
@@ -2453,7 +2453,7 @@ void checkStmtSwitch(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
     if (stmt->Switch.match) {
         switchType = checkExpr(stmt->Switch.match, &switchCtx, pkg);
         if (!isNumericOrPointer(switchType) && !isBoolean(switchType)) {
-            ReportError(pkg, CannotSwitchError, stmt->Switch.match->start,
+            ReportErrorRange(pkg, CannotSwitchError, stmt->Switch.match->pos,
                         "Cannot switch on value of type %s", DescribeType(switchType));
         }
     }
@@ -2465,12 +2465,12 @@ void checkStmtSwitch(Stmt *stmt, CheckerContext *ctx, Package *pkg) {
         ForEach(switchCase->SwitchCase.matches, Expr *) {
             Type *type = checkExpr(it, &switchCtx, pkg);
             if (!coerceType(it, &switchCtx, &type, switchType, pkg)) {
-                ReportError(pkg, TypeMismatchError, it->start, "Cannot convert %s to type %s",
+                ReportErrorRange(pkg, TypeMismatchError, it->pos, "Cannot convert %s to type %s",
                             DescribeType(type), DescribeType(switchType));
             }
         }
         if (!switchCase->SwitchCase.matches && i + 1 != ArrayLen(stmt->Switch.cases)) {
-            ReportError(pkg, DefaultSwitchCaseNotLastError, switchCase->start,
+            ReportErrorRange(pkg, DefaultSwitchCaseNotLastError, switchCase->pos,
                         "The default switch case must be the final case");
         }
 
@@ -2625,7 +2625,7 @@ void test_checkConstantDeclarations() {
     ASSERT(sym->state == SymbolState_Resolved);
     ASSERT(!sym->used);
     ASSERT(sym->kind == SymbolKind_Constant);
-    ASSERT(sym->decl->start.offset == 0);
+    ASSERT(sym->decl->pos.offset == 0);
     ASSERT(sym->val.u64 == 8);
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -177,6 +177,13 @@ struct Position {
     u32 offset, line, column;
 };
 
+typedef struct SourceRange {
+    const char *name;
+    u32 offset;    // offset in file
+    u32 endOffset; // offset in file
+    u32 line, column;
+} SourceRange;
+
 /// Allocators
 typedef enum AllocKind {
     AT_Alloc,

--- a/src/common.h
+++ b/src/common.h
@@ -1,7 +1,12 @@
 
+#ifdef __GLIBC__
+// We need to define this for 'realpath' to be included
+#define _GNU_SOURCE
+#endif
+
+#include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
 #include <stddef.h>

--- a/src/error.c
+++ b/src/error.c
@@ -75,6 +75,7 @@ struct DiagnosticNote {
 typedef struct DiagnosticError DiagnosticError;
 struct DiagnosticError {
     const char *msg;
+    const char *sourceDescription;
     DiagnosticNote *note;
 };
 
@@ -83,6 +84,131 @@ b32 shouldPrintErrorCode() {
 }
 
 #define HasErrors(p) (p)->diagnostics.errors
+
+char *highlightLine(
+                   char *buf, const char *bufend,
+                   const char *line, const char *lineEnd,
+                   const char *start, const char *end)
+{
+
+    ASSERT(line <= start);
+    ASSERT(lineEnd >= end);
+    int lengthRequired = 0;
+
+    // Print line up until start into buf
+    lengthRequired = snprintf(buf, bufend - buf, "%.*s", (int)(start - line), line);
+    if (lengthRequired > bufend - buf) return NULL;
+    buf += lengthRequired;
+    line += lengthRequired;
+
+    if (FlagErrorColors) {
+        // Print highlight codes
+        lengthRequired = snprintf(buf, bufend - buf, "\x1B[31m");
+        if (lengthRequired > bufend - buf) return NULL;
+        buf += lengthRequired;
+    }
+
+    ASSERT(line == start);
+
+    // Print error range
+    lengthRequired = snprintf(buf, bufend - buf, "%.*s", (int)(end - start), line);
+    if (lengthRequired > bufend - buf) return NULL;
+    buf += lengthRequired;
+    line += lengthRequired;
+
+    if (FlagErrorColors) {
+        // Print reset code
+        lengthRequired = snprintf(buf, bufend - buf, "\x1B[0m");
+        if (lengthRequired > bufend - buf) return NULL;
+        buf += lengthRequired;
+    }
+
+    // Print the remaining line
+    lengthRequired = snprintf(buf, bufend - buf, "%.*s\n", (int)(lineEnd - line), line);
+    if (lengthRequired > bufend - buf) return NULL;
+    buf += lengthRequired;
+    line += lengthRequired;
+
+    // + 1 because we append a newline
+    ASSERT(line == lineEnd + 1);
+
+    return buf;
+}
+
+const char *findCodeBlockAndHighlightError(Package *p, SourceRange range) {
+    if (!p->fileHandle) return NULL;
+
+#define MAX_LINES 3
+#define MAX_LINE_LENGTH 512
+
+    const char *fileStart = p->fileHandle;
+
+    // We add 1 so we have a buffer incase we have color turned off and need to add ^^^^^^ pointers.
+    char lines[MAX_LINES + 1][MAX_LINE_LENGTH];
+    char noColorHighlight[MAX_LINE_LENGTH];
+
+    const char *cursor = &fileStart[range.offset];
+
+    int numberOfBytes = 0;
+    int numberOfLines = 0;
+    for (int line = 0; line < MAX_LINES; line++) {
+        const char *lineStart = cursor;
+        const char *lineEnd = cursor;
+        while(*cursor != '\n') {
+            if (!isspace(*cursor)) lineStart = cursor;
+            cursor--;
+        }
+
+        while(*lineEnd != '\n') lineEnd++;
+
+        if (line != 0) {
+            numberOfBytes += snprintf(lines[line], sizeof(lines[line]), "%.*s\n", (int)(lineEnd - lineStart), lineStart);
+        } else {
+
+            char *buf = &lines[line][0];
+
+            u32 lineStartOffset = (u32) (lineStart - fileStart);
+            u32 errorStartOffsetInLine = range.offset - lineStartOffset;
+            u32 errorEndOffsetInLine = errorStartOffsetInLine + range.endOffset - range.offset;
+
+            char *result = highlightLine(
+               buf, buf + MAX_LINE_LENGTH,
+               lineStart, lineEnd,
+               lineStart + errorStartOffsetInLine, lineStart + errorEndOffsetInLine
+            );
+            if (!result) return NULL;
+            numberOfBytes += strlen(buf);
+
+            if (!FlagErrorColors) {
+                memset(noColorHighlight, ' ', lineEnd - lineStart + 1);
+                memset(noColorHighlight + errorStartOffsetInLine, '^', range.endOffset - range.offset);
+                noColorHighlight[lineEnd - lineStart] = '\n';
+            }
+        }
+
+        cursor--;
+        if (*cursor == '\n') {
+            // The line is empty, break
+            break;
+        }
+
+        numberOfLines++;
+    }
+
+    numberOfBytes += 4 + 1; // 4 for indentation 1 for nul termination.
+    if (!FlagErrorColors) numberOfBytes += strlen(lines[numberOfLines - 1]) + 1;
+    char *results = ArenaAlloc(&p->diagnostics.arena, numberOfBytes + 1 + 40);
+
+    char *resultsCursor = results;
+    for (int line = numberOfLines - 1; line >= 0; line--) {
+        resultsCursor += sprintf(resultsCursor, "\t%s", lines[line]);
+    }
+    if (!FlagErrorColors)
+        resultsCursor += sprintf(resultsCursor, "\t%s", noColorHighlight);
+    *resultsCursor = '\0';
+    return results;
+#undef MAX_LINES
+}
 
 void ReportErrorRange(Package *p, ErrorCode code, SourceRange range, const char *msg, ...) {
     va_list args;
@@ -103,7 +229,12 @@ void ReportErrorRange(Package *p, ErrorCode code, SourceRange range, const char 
     memcpy(errorMsg, errorBuffer, errlen + 1);
     va_end(args);
 
-    DiagnosticError error = { errorMsg };
+    const char *codeBlock = NULL;
+    if (FlagErrorSource) {
+        codeBlock = findCodeBlockAndHighlightError(p, range);
+    }
+
+    DiagnosticError error = { errorMsg, codeBlock };
     ArrayPush(p->diagnostics.errors, error);
 }
 
@@ -193,11 +324,15 @@ char outputErrorBuffer[8096];
 #define outputDiagnostic(fmt, __VA_ARGS__) snprintf(outputErrorBuffer, sizeof(outputErrorBuffer), fmt, __VA_ARGS__)
 #else
 #define outputDiagnostic(fmt, __VA_ARGS__) fprintf(stderr, fmt, __VA_ARGS__)
+
 #endif
 
 void OutputReportedErrors(Package *p) {
     For (p->diagnostics.errors) {
         outputDiagnostic("%s", p->diagnostics.errors[i].msg);
+        if (p->diagnostics.errors[i].sourceDescription) {
+            fprintf(stderr, "\n%s\n", p->diagnostics.errors[i].sourceDescription);
+        }
         for (DiagnosticNote *note = p->diagnostics.errors[i].note; note; note = note->next) {
             outputDiagnostic("%s", note->msg);
         }

--- a/src/flags.c
+++ b/src/flags.c
@@ -3,7 +3,6 @@
 
 bool FlagParseComments;
 bool FlagErrorCodes = true;
-bool FlagErrorLineNumbers = true;
 bool FlagErrorColors = true;
 bool FlagErrorSource = true;
 bool FlagVerbose;
@@ -42,7 +41,6 @@ CLIFlag CLIFlags[] = {
 
     { CLIFlagKind_Bool, "error-codes", .ptr.b = &FlagErrorCodes,              .help = "Show error codes along side error location" },
     { CLIFlagKind_Bool, "error-colors", .ptr.b = &FlagErrorColors,            .help = "Show errors in souce code by highlighting in color" },
-    { CLIFlagKind_Bool, "error-line-numbers", .ptr.b = &FlagErrorLineNumbers, .help = "Show line numbers in error source" },
     { CLIFlagKind_Bool, "error-source", .ptr.b = &FlagErrorSource,            .help = "Show source code when printing errors" },
 
     { CLIFlagKind_Bool, "parse-comments", .ptr.b = &FlagParseComments, .help = NULL },

--- a/src/flags.c
+++ b/src/flags.c
@@ -3,6 +3,9 @@
 
 bool FlagParseComments;
 bool FlagErrorCodes = true;
+bool FlagErrorLineNumbers = true;
+bool FlagErrorColors = true;
+bool FlagErrorSource = true;
 bool FlagVerbose;
 bool FlagVersion;
 bool FlagHelp;
@@ -31,12 +34,17 @@ CLIFlag CLIFlags[] = {
 
     { CLIFlagKind_String, "output", "o", .ptr.s = &OutputName, .argumentName = "file", .help = "Output file (default: out_<input>)" },
 
-    { CLIFlagKind_Bool, "verbose", "v", .ptr.b = &FlagVerbose,         .help = "Enable verbose output" },
-    { CLIFlagKind_Bool, "dump-ir", .ptr.b = &FlagDumpIR,               .help = "Dump LLVM IR" },
-    { CLIFlagKind_Bool, "emit-ir", .ptr.b = &FlagEmitIR,               .help = "Emit LLVM IR file(s)" },
-    { CLIFlagKind_Bool, "emit-header", .ptr.b = &FlagEmitHeader,       .help = "Emit C header file(s)" },
-    { CLIFlagKind_Bool, "emit-times", .ptr = NULL,                     .help = "Emit times for each stage of compilation" },
-    { CLIFlagKind_Bool, "error-codes", .ptr.b = &FlagErrorCodes,       .help = "Display error codes along side error location" },
+    { CLIFlagKind_Bool, "verbose", "v", .ptr.b = &FlagVerbose,   .help = "Enable verbose output" },
+    { CLIFlagKind_Bool, "dump-ir", .ptr.b = &FlagDumpIR,         .help = "Dump LLVM IR" },
+    { CLIFlagKind_Bool, "emit-ir", .ptr.b = &FlagEmitIR,         .help = "Emit LLVM IR file(s)" },
+    { CLIFlagKind_Bool, "emit-header", .ptr.b = &FlagEmitHeader, .help = "Emit C header file(s)" },
+    { CLIFlagKind_Bool, "emit-times", .ptr = NULL,               .help = "Emit times for each stage of compilation" },
+
+    { CLIFlagKind_Bool, "error-codes", .ptr.b = &FlagErrorCodes,              .help = "Show error codes along side error location" },
+    { CLIFlagKind_Bool, "error-colors", .ptr.b = &FlagErrorColors,            .help = "Show errors in souce code by highlighting in color" },
+    { CLIFlagKind_Bool, "error-line-numbers", .ptr.b = &FlagErrorLineNumbers, .help = "Show line numbers in error source" },
+    { CLIFlagKind_Bool, "error-source", .ptr.b = &FlagErrorSource,            .help = "Show source code when printing errors" },
+
     { CLIFlagKind_Bool, "parse-comments", .ptr.b = &FlagParseComments, .help = NULL },
     { CLIFlagKind_Bool, "debug", "g",  .ptr.b = &FlagDebug,            .help = "Include debug symbols"},
     { CLIFlagKind_Bool, "link", .ptr.b = &FlagLink,                    .help = "Link object files (default)"},

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -131,14 +131,14 @@ const char *DescribeToken(Token tok) {
     return DescribeTokenKind(tok.kind);
 }
 
-Lexer MakeLexer(const char *data, const char *name) {
+Lexer MakeLexer(const char *data, Package *pkg) {
     Lexer l = {0};
 
     l.stream = data;
     l.startOfLine = data;
     l.startOfFile = data;
 
-    l.pos.name = name;
+    l.pos.name = pkg->path;
     l.pos.line = 1;
 
     return l;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -138,7 +138,7 @@ Lexer MakeLexer(const char *data, Package *pkg) {
     l.startOfLine = data;
     l.startOfFile = data;
 
-    l.pos.name = pkg->path;
+    l.pos.name = pkg ? pkg->path : "<builtin>";
     l.pos.line = 1;
 
     return l;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -199,7 +199,7 @@ u32 scanNumericEscape(Lexer *l, i32 n, u32 max) {
     return x;
 
 error:
-    ReportErrorPosition(l->package, InvalidEscapeError, l->pos, "Escape sequence is an invalid Unicode codepoint");
+    ReportError(l->package, InvalidEscapeError, rangeFromPosition(l->pos), "Escape sequence is an invalid Unicode codepoint");
     return 0;
 }
 
@@ -220,8 +220,8 @@ const char *scanString(Lexer *l) {
         u32 cp = NextCodePoint(l);
         u32 val;
         if (cp == '\n' && !isMultiline) {
-            ReportErrorPosition(l->package, StringContainsNewlineError, l->pos, "String literal cannot contain a newline");
-            ReportNote(l->package, l->pos, "Multiline string literals use `backticks` instead of \"quotes\"");
+            ReportError(l->package, StringContainsNewlineError, rangeFromPosition(l->pos), "String literal cannot contain a newline");
+            ReportNote(l->package, rangeFromPosition(l->pos), "Multiline string literals use `backticks` instead of \"quotes\"");
             return NULL;
         } else if (cp == '\\') {
             cp = NextCodePoint(l);
@@ -245,7 +245,7 @@ const char *scanString(Lexer *l) {
                     error: ;
                         u32 cpWidth;
                         DecodeCodePoint(&cpWidth, l->stream);
-                        ReportErrorPosition(l->package, InvalidCharacterEscapeError, l->pos, "Invalid character literal escape '\\%.*s'", cpWidth, l->stream);
+                        ReportError(l->package, InvalidCharacterEscapeError, rangeFromPosition(l->pos), "Invalid character literal escape '\\%.*s'", cpWidth, l->stream);
                         return NULL;
                     }
             }
@@ -259,8 +259,8 @@ const char *scanString(Lexer *l) {
 
     u32 closingQuote = NextCodePoint(l);
     if (closingQuote == FileEnd) {
-        ReportErrorPosition(l->package, UnexpectedEOFError, l->pos, "Unexpectedly reached end of file while parsing string literal");
-        ReportNote(l->package, start, "String began here");
+        ReportError(l->package, UnexpectedEOFError, rangeFromPosition(l->pos), "Unexpectedly reached end of file while parsing string literal");
+        ReportNote(l->package, rangeFromPosition(start), "String began here");
         return NULL;
     }
     ASSERT(closingQuote == quote);
@@ -290,7 +290,7 @@ double scanFloat(Lexer *l) {
         if (!isdigit(*l->stream)) {
             u32 cpWidth;
             DecodeCodePoint(&cpWidth, l->stream);
-            ReportErrorPosition(l->package, ExpectedDigitError, l->pos, "Expected digit after float literal exponent, found '%.*s'", cpWidth, l->stream);
+            ReportError(l->package, ExpectedDigitError, rangeFromPosition(l->pos), "Expected digit after float literal exponent, found '%.*s'", cpWidth, l->stream);
         }
         while (isdigit(*l->stream)) {
             l->stream++;
@@ -299,7 +299,7 @@ double scanFloat(Lexer *l) {
 
     double val = strtod(start, NULL);
     if (val == HUGE_VAL) {
-        ReportErrorPosition(l->package, FloatOverflowError, l->pos, "Float literal is larger than maximum allowed value");
+        ReportError(l->package, FloatOverflowError, rangeFromPosition(l->pos), "Float literal is larger than maximum allowed value");
         return 0.f;
     }
     return val;
@@ -341,10 +341,10 @@ u64 scanInt(Lexer *l) {
         if (digit >= base) {
             u32 cpWidth;
             DecodeCodePoint(&cpWidth, l->stream);
-            ReportErrorPosition(l->package, DigitOutOfRangeError, l->pos, "Digit '%.*s' out of range for base '%d'", cpWidth, l->stream, base);
+            ReportError(l->package, DigitOutOfRangeError, rangeFromPosition(l->pos), "Digit '%.*s' out of range for base '%d'", cpWidth, l->stream, base);
         }
         if (val > (ULLONG_MAX - digit) / base) {
-            ReportErrorPosition(l->package, IntOverflowError, l->pos, "Integer literal is larger than maximum allowed value");
+            ReportError(l->package, IntOverflowError, rangeFromPosition(l->pos), "Integer literal is larger than maximum allowed value");
             while (isdigit(*l->stream)) {
                 l->stream++;
             }
@@ -357,7 +357,7 @@ u64 scanInt(Lexer *l) {
     if (l->stream == start_digits) {
         u32 cpWidth;
         DecodeCodePoint(&cpWidth, l->stream);
-        ReportErrorPosition(l->package, DigitOutOfRangeError, l->pos, "Digit '%.*s' out of range for base '%d'", cpWidth, l->stream, base);
+        ReportError(l->package, DigitOutOfRangeError, rangeFromPosition(l->pos), "Digit '%.*s' out of range for base '%d'", cpWidth, l->stream, base);
     }
     return val;
 }
@@ -567,7 +567,7 @@ repeat: ;
         case '#': {
             token.kind = TK_Directive;
             l->stream++;
-            if (*l->stream == FileEnd) ReportErrorPosition(l->package, UnexpectedEOFError, l->pos, "Unexpectedly reached end of file while parsing directive");
+            if (*l->stream == FileEnd) ReportError(l->package, UnexpectedEOFError, rangeFromPosition(l->pos), "Unexpectedly reached end of file while parsing directive");
 
             u32 cpWidth;
             u32 cp = DecodeCodePoint(&cpWidth, l->stream);
@@ -591,12 +591,12 @@ repeat: ;
             if (!IsIdentifierHead(cp)) {
                 switch (cp) {
                     case LeftDoubleQuote:
-                        ReportErrorPosition(l->package, WrongDoubleQuoteError, l->pos, "Unsupported unicode character '“' (0x201c). Did you mean `\"`?");
+                        ReportError(l->package, WrongDoubleQuoteError, rangeFromPosition(l->pos), "Unsupported unicode character '“' (0x201c). Did you mean `\"`?");
                         break;
                     default: {
                         char buff[4];
                         u32 len = EncodeCodePoint(buff, cp);
-                        ReportErrorPosition(l->package, InvalidCodePointError, l->pos, "Invalid Unicode codepoint '%.*s'", len, buff);
+                        ReportError(l->package, InvalidCodePointError, rangeFromPosition(l->pos), "Invalid Unicode codepoint '%.*s'", len, buff);
                     }
                 }
                 l->stream++;

--- a/src/llvm.cpp
+++ b/src/llvm.cpp
@@ -822,7 +822,7 @@ llvm::Value *emitExprBinary(Context *ctx, Expr *expr) {
     lhs = emitExpr(ctx, expr->Binary.lhs, /*desiredType:*/ ty);
     rhs = emitExpr(ctx, expr->Binary.rhs, /*desiredType:*/ ty);
 
-    debugPos(ctx, expr->Binary.pos);
+    debugPos(ctx, expr->Binary.op.pos);
     switch (expr->Binary.op.kind) {
         case TK_Add:
             return isInt ? ctx->b.CreateAdd(lhs, rhs) : ctx->b.CreateFAdd(lhs, rhs);

--- a/src/llvm.cpp
+++ b/src/llvm.cpp
@@ -105,7 +105,7 @@ struct BackendStructUserdata {
 };
 
 void clearDebugPos(Context *ctx);
-void debugPos(Context *ctx, Position pos);
+void debugPos(Context *ctx, SourceRange pos);
 b32 emitObjectFile(Package *p, char *name, Context *ctx);
 llvm::Value *emitExpr(Context *ctx, Expr *expr, llvm::Type *desiredType = nullptr);
 llvm::Value *emitExprBinary(Context *ctx, Expr *expr);
@@ -292,7 +292,7 @@ llvm::DIType *debugCanonicalize(Context *ctx, Type *type) {
             ctx->d.scope,
             type->Symbol->name,
             ctx->d.file,
-            type->Symbol->decl->start.line,
+            type->Symbol->decl->pos.line,
             type->Width,
             type->Align,
             llvm::DINode::DIFlags::FlagZero,
@@ -363,7 +363,7 @@ llvm::AllocaInst *createEntryBlockAlloca(Context *ctx, llvm::Type *type, const c
     return alloca;
 }
 
-llvm::Value *createVariable(Symbol *symbol, Position pos, Context *ctx) {
+llvm::Value *createVariable(Symbol *symbol, SourceRange pos, Context *ctx) {
     ASSERT(symbol->kind == SymbolKind_Variable);
 
     if (symbol->flags & SymbolFlag_Global) {
@@ -575,7 +575,7 @@ llvm::Value *emitExprCall(Context *ctx, Expr *expr) {
         args.push_back(irArg);
     }
     auto irFunc = emitExpr(ctx, expr->Call.expr);
-    debugPos(ctx, expr->Call.start);
+    debugPos(ctx, expr->Call.pos);
     return ctx->b.CreateCall(irFunc, args);
 }
 
@@ -700,7 +700,7 @@ llvm::Value *emitExprSelector(Context *ctx, Expr *expr) {
 }
 
 llvm::Value *emitExpr(Context *ctx, Expr *expr, llvm::Type *desiredType) {
-    debugPos(ctx, expr->start);
+    debugPos(ctx, expr->pos);
 
     llvm::Value *value = NULL;
     switch (expr->kind) {
@@ -790,7 +790,7 @@ llvm::Value *emitExprUnary(Context *ctx, Expr *expr) {
         val = emitExpr(ctx, unary.expr);
     }
 
-    debugPos(ctx, expr->Unary.start);
+    debugPos(ctx, expr->Unary.pos);
     switch (unary.op) {
         case TK_Add:
         case TK_And:
@@ -822,7 +822,8 @@ llvm::Value *emitExprBinary(Context *ctx, Expr *expr) {
     lhs = emitExpr(ctx, expr->Binary.lhs, /*desiredType:*/ ty);
     rhs = emitExpr(ctx, expr->Binary.rhs, /*desiredType:*/ ty);
 
-    debugPos(ctx, expr->Binary.op.pos);
+    // FIXME: 
+//    debugPos(ctx, expr->Binary.op.pos);
     switch (expr->Binary.op.kind) {
         case TK_Add:
             return isInt ? ctx->b.CreateAdd(lhs, rhs) : ctx->b.CreateFAdd(lhs, rhs);
@@ -979,7 +980,7 @@ llvm::Value *emitExprSubscript(Context *ctx, Expr *expr) {
 
 llvm::Function *emitExprLitFunction(Context *ctx, Expr *expr, llvm::Function *fn = nullptr) {
     CheckerInfo info = ctx->checkerInfo[expr->id];
-    debugPos(ctx, expr->start);
+    debugPos(ctx, expr->pos);
 
     if (!fn) {
         llvm::FunctionType *type = (llvm::FunctionType *) canonicalize(ctx, info.BasicExpr.type);
@@ -1003,11 +1004,11 @@ llvm::Function *emitExprLitFunction(Context *ctx, Expr *expr, llvm::Function *fn
             fn->getName(),      // Name (will be set correctly by the caller) (TODO)
             fn->getName(),      // LinkageName
             ctx->d.file,
-            expr->start.line,
+            expr->pos.line,
             dbgType,
             false,              // isLocalToUnit
             true,               // isDefinition
-            expr->LitFunction.body->start.line,
+            expr->LitFunction.body->pos.line,
             llvm::DINode::FlagPrototyped,
             false               // isOptimized (TODO)
         );
@@ -1038,11 +1039,11 @@ llvm::Function *emitExprLitFunction(Context *ctx, Expr *expr, llvm::Function *fn
                 paramInfo.Ident.symbol->name,
                 (u32) i,
                 ctx->d.file,
-                it->start.line,
+                it->pos.line,
                 debugCanonicalize(ctx, paramInfo.Ident.symbol->type),
                 true
             );
-            auto pos = ((Expr_KeyValue *) paramInfo.Ident.symbol->decl)->start;
+            auto pos = ((Expr_KeyValue *) paramInfo.Ident.symbol->decl)->pos;
             ctx->d.builder->insertDeclare(
                 storage,
                 dbg,
@@ -1160,7 +1161,7 @@ llvm::StructType *emitExprTypeStruct(Context *ctx, Expr *expr) {
                 ctx->d.scope,
                 item.names[j],
                 ctx->d.file,
-                item.start.line,
+                item.pos.line,
                 fieldType->Width,
                 fieldType->Align,
                 type->Struct.members[index].offset,
@@ -1188,7 +1189,7 @@ llvm::StructType *emitExprTypeStruct(Context *ctx, Expr *expr) {
         ctx->d.scope,
         type->Symbol->name,
         ctx->d.file,
-        type->Symbol->decl->start.line,
+        type->Symbol->decl->pos.line,
         type->Width,
         type->Align,
         llvm::DINode::DIFlags::FlagZero,
@@ -1234,7 +1235,7 @@ void emitDeclConstant(Context *ctx, Decl *decl) {
 
     // TODO: CreateLifetimeStart for this symbol (if applicable)
 
-    debugPos(ctx, decl->start);
+    debugPos(ctx, decl->pos);
     if (symbol->type->kind == TypeKind_Function && decl->Constant.values[0]->kind == ExprKind_LitFunction) {
 
         CheckerInfo info = ctx->checkerInfo[decl->Constant.values[0]->id];
@@ -1304,11 +1305,11 @@ void emitDeclVariable(Context *ctx, Decl *decl) {
             Conversion *conversions = ctx->checkerInfo[decl->id].Variable.conversions;
 
             size_t numValues = exprType->Tuple.numTypes;
-            debugPos(ctx, var.names[lhsIndex]->start);
+            debugPos(ctx, var.names[lhsIndex]->pos);
 
             if (numValues == 1) {
                 Symbol *symbol = symbols[lhsIndex];
-                llvm::Value *lhs = createVariable(symbol, var.names[lhsIndex]->start, ctx);
+                llvm::Value *lhs = createVariable(symbol, var.names[lhsIndex]->pos, ctx);
 
                 // Conversions of tuples like this are stored on the lhs
                 if (conversions[lhsIndex] != ConversionKind_None) {
@@ -1327,7 +1328,7 @@ void emitDeclVariable(Context *ctx, Decl *decl) {
 
                 for (size_t resultIndex = 0; resultIndex < numValues; resultIndex++) {
                     Symbol *symbol = symbols[lhsIndex];
-                    llvm::Value *lhs = createVariable(symbol, var.names[lhsIndex]->start, ctx);
+                    llvm::Value *lhs = createVariable(symbol, var.names[lhsIndex]->pos, ctx);
 
                     llvm::Value *addr = ctx->b.CreateStructGEP(rhs->getType(), resultAddress, (u32) resultIndex);
                     llvm::Value *val = ctx->b.CreateLoad(addr);
@@ -1344,8 +1345,8 @@ void emitDeclVariable(Context *ctx, Decl *decl) {
             }
         } else {
             Symbol *symbol = symbols[lhsIndex];
-            createVariable(symbol, var.names[lhsIndex]->start, ctx);
-            debugPos(ctx, decl->start);
+            createVariable(symbol, var.names[lhsIndex]->pos, ctx);
+            debugPos(ctx, decl->pos);
             setVariableInitializer(symbol, ctx, rhs);
             lhsIndex += 1;
         }
@@ -1357,7 +1358,7 @@ void emitDeclForeign(Context *ctx, Decl *decl) {
     ASSERT(decl->kind == DeclKind_Foreign);
     CheckerInfo info = ctx->checkerInfo[decl->id];
 
-    debugPos(ctx, decl->start);
+    debugPos(ctx, decl->pos);
     llvm::Type *type = canonicalize(ctx, info.Foreign.symbol->type);
 
     switch (info.Foreign.symbol->type->kind) {
@@ -1389,7 +1390,7 @@ void emitDeclForeignBlock(Context *ctx, Decl *decl) {
     size_t len = ArrayLen(decl->ForeignBlock.members);
     for (size_t i = 0; i < len; i++) {
         Decl_ForeignBlockMember it = decl->ForeignBlock.members[i];
-        debugPos(ctx, it.start);
+        debugPos(ctx, it.pos);
         llvm::Type *type = canonicalize(ctx, it.symbol->type);
 
         switch (it.symbol->type->kind) {
@@ -1440,7 +1441,7 @@ void emitStmtAssign(Context *ctx, Stmt *stmt) {
                 ctx->returnAddress = true;
                 llvm::Value *lhs = emitExpr(ctx, assign.lhs[lhsIndex++]);
                 ctx->returnAddress = false;
-                debugPos(ctx, assign.start);
+                debugPos(ctx, assign.pos);
                 ctx->b.CreateAlignedStore(rhs, lhs, BytesFromBits(exprType->Tuple.types[0]->Align));
             } else {
                 // create some stack space to land the returned struct onto
@@ -1452,7 +1453,7 @@ void emitStmtAssign(Context *ctx, Stmt *stmt) {
                     ctx->returnAddress = true;
                     llvm::Value *lhs = emitExpr(ctx, lhsExpr);
                     ctx->returnAddress = false;
-                    debugPos(ctx, assign.start);
+                    debugPos(ctx, assign.pos);
 
                     llvm::Value *addr = ctx->b.CreateStructGEP(rhs->getType(), resultAddress, (u32) resultIndex);
                     llvm::Value *val = ctx->b.CreateLoad(addr);
@@ -1473,7 +1474,7 @@ void emitStmtAssign(Context *ctx, Stmt *stmt) {
             llvm::Value *lhs = emitExpr(ctx, lhsExpr);
             ctx->returnAddress = false;
             Type *type = TypeFromCheckerInfo(ctx->checkerInfo[lhsExpr->id]);
-            debugPos(ctx, assign.start);
+            debugPos(ctx, assign.pos);
             ctx->b.CreateAlignedStore(rhs, lhs, BytesFromBits(type->Align));
         }
     }
@@ -1486,7 +1487,7 @@ void emitStmtIf(Context *ctx, Stmt *stmt) {
     auto post = llvm::BasicBlock::Create(ctx->m->getContext(), "if.post", ctx->fn);
 
     auto cond = emitExpr(ctx, stmt->If.cond, llvm::IntegerType::get(ctx->m->getContext(), 1));
-    debugPos(ctx, stmt->If.start);
+    debugPos(ctx, stmt->If.pos);
     ctx->b.CreateCondBr(cond, pass, fail ? fail : post);
 
     ctx->b.SetInsertPoint(pass);
@@ -1527,7 +1528,7 @@ void emitStmtReturn(Context *ctx, Stmt *stmt) {
     } else if (values.size() == 1) {
         ctx->b.CreateStore(values[0], ctx->retValue);
     }
-    debugPos(ctx, stmt->start);
+    debugPos(ctx, stmt->pos);
     ctx->b.CreateBr(ctx->retBlock);
 }
 
@@ -1556,11 +1557,11 @@ void emitStmtFor(Context *ctx, Stmt *stmt) {
     llvm::DIScope *oldScope = NULL;
     if (FlagDebug) {
         oldScope = ctx->d.scope;
-        ctx->d.scope = ctx->d.builder->createLexicalBlock(oldScope, ctx->d.file, stmt->start.line, stmt->start.column);
+        ctx->d.scope = ctx->d.builder->createLexicalBlock(oldScope, ctx->d.file, stmt->pos.line, stmt->pos.column);
     }
 
     if (fore.init) {
-        debugPos(ctx, fore.init->start);
+        debugPos(ctx, fore.init->pos);
         emitStmt(ctx, fore.init);
     }
 
@@ -1596,7 +1597,7 @@ void emitStmtFor(Context *ctx, Stmt *stmt) {
         llvm::DIScope *oldScope = NULL;
         if (FlagDebug) {
             oldScope = ctx->d.scope;
-            ctx->d.scope = ctx->d.builder->createLexicalBlock(oldScope, ctx->d.file, fore.body->start.line, fore.body->start.column);
+            ctx->d.scope = ctx->d.builder->createLexicalBlock(oldScope, ctx->d.file, fore.body->pos.line, fore.body->pos.column);
         }
 
         ForEachWithIndex(fore.body->stmts, i, Stmt *, stmt) {
@@ -1912,9 +1913,7 @@ b32 CodegenLLVM(Package *p) {
     // NOTE: Unset the location for the prologue emission (leading instructions
     // with nolocation in a function are considered part of the prologue and the
     // debugger will run past them when breaking on a function)
-    Position pos;
-    pos.line = 0;
-    pos.column = 0;
+    SourceRange pos = {.line = 1};
     debugPos(&ctx, pos);
 
     For (p->stmts) {
@@ -2006,7 +2005,7 @@ void clearDebugPos(Context *ctx) {
     ctx->b.SetCurrentDebugLocation(llvm::DebugLoc());
 }
 
-void debugPos(Context *ctx, Position pos) {
+void debugPos(Context *ctx, SourceRange pos) {
     if (!FlagDebug) return;
     ctx->b.SetCurrentDebugLocation(llvm::DebugLoc::get(pos.line, pos.column, ctx->d.scope));
 }

--- a/src/llvm.cpp
+++ b/src/llvm.cpp
@@ -823,7 +823,7 @@ llvm::Value *emitExprBinary(Context *ctx, Expr *expr) {
     rhs = emitExpr(ctx, expr->Binary.rhs, /*desiredType:*/ ty);
 
     debugPos(ctx, expr->Binary.pos);
-    switch (expr->Binary.op) {
+    switch (expr->Binary.op.kind) {
         case TK_Add:
             return isInt ? ctx->b.CreateAdd(lhs, rhs) : ctx->b.CreateFAdd(lhs, rhs);
         case TK_Sub:

--- a/src/os.c
+++ b/src/os.c
@@ -11,14 +11,6 @@ char *AbsolutePath(const char *filename, char *resolved) {
 #endif
 }
 
-typedef struct FileData {
-    const char *path;
-    const char *code;
-    size_t len;
-} FileData;
-
-FileData *files;
-
 // FIXME: We are mmap()'ing this with no way to munmap it currently
 char *ReadEntireFile(const char *path) {
     char *address = NULL;
@@ -35,8 +27,6 @@ char *ReadEntireFile(const char *path) {
     if (close(fd) == -1) perror("close was interupted"); // intentionally continue despite the failure, just keep the file open
     if (address == MAP_FAILED) return NullWithLoggedReason("Failed to mmap opened file %s", path);
     close(fd);
-    FileData data = {path, address, len};
-    ArrayPush(files, data);
 #else
     FILE *fd = fopen(path, "rb");
     if (!fd) return (char *)NullWithLoggedReason("failed to  open file %s", path);
@@ -52,9 +42,6 @@ char *ReadEntireFile(const char *path) {
     }
 
     fclose(fd);
-
-    FileData data = {path, address, len};
-    ArrayPush(files, data);
 #endif
 
     return address;

--- a/src/os.c
+++ b/src/os.c
@@ -11,13 +11,20 @@ char *AbsolutePath(const char *filename, char *resolved) {
 #endif
 }
 
+typedef struct FileData {
+    const char *path;
+    const char *code;
+    size_t len;
+} FileData;
+
+FileData *files;
 
 // FIXME: We are mmap()'ing this with no way to munmap it currently
 char *ReadEntireFile(const char *path) {
     char *address = NULL;
 
 #ifdef SYSTEM_POSIX
-    i32 fd = open(path, O_RDONLY);
+    i32 fd = open(path, O_RDONLY); // FIXME: No matching close
     if (fd == -1) return NullWithLoggedReason("failed to open file %s", path);
 
     struct stat st;
@@ -27,6 +34,9 @@ char *ReadEntireFile(const char *path) {
     address = (char *) mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd, 0);
     if (close(fd) == -1) perror("close was interupted"); // intentionally continue despite the failure, just keep the file open
     if (address == MAP_FAILED) return NullWithLoggedReason("Failed to mmap opened file %s", path);
+    close(fd);
+    FileData data = {path, address, len};
+    ArrayPush(files, data);
 #else
     FILE *fd = fopen(path, "rb");
     if (!fd) return (char *)NullWithLoggedReason("failed to  open file %s", path);
@@ -42,6 +52,9 @@ char *ReadEntireFile(const char *path) {
     }
 
     fclose(fd);
+
+    FileData data = {path, address, len};
+    ArrayPush(files, data);
 #endif
 
     return address;

--- a/src/parser.c
+++ b/src/parser.c
@@ -557,7 +557,6 @@ Expr *parseExprBinary(Parser *p, i32 prec1, b32 noCompoundLiteral) {
     Expr *lhs = parseExprUnary(p, noCompoundLiteral);
     for (;;) {
         Token op = p->tok;
-        Position pos = p->tok.pos;
         i32 precedence = PrecedenceForTokenKind[op.kind];
         if (precedence < prec1) return lhs;
         nextToken();
@@ -572,7 +571,7 @@ Expr *parseExprBinary(Parser *p, i32 prec1, b32 noCompoundLiteral) {
             return NewExprTernary(p->package, lhs, pass, fail);
         }
         Expr *rhs = parseExprBinary(p, precedence + 1, noCompoundLiteral);
-        lhs = NewExprBinary(p->package, op, pos, lhs, rhs);
+        lhs = NewExprBinary(p->package, op, lhs, rhs);
     }
 }
 
@@ -749,15 +748,14 @@ Stmt *parseSimpleStmt(Parser *p, b32 noCompoundLiteral, b32 *isIdentList) {
         case TK_AddAssign: case TK_SubAssign: case TK_MulAssign: case TK_DivAssign:
         case TK_RemAssign: case TK_AndAssign: case TK_OrAssign:
         case TK_XorAssign: case TK_ShlAssign: case TK_ShrAssign: {
-            Position pos = p->tok.pos;
             Token op = p->tok;
             op.kind = TokenAssignOffset(op.kind);
             nextToken();
             DynamicArray(Expr *) rhs = parseExprList(p, noCompoundLiteral);
             if (ArrayLen(rhs) > 1) {
-                ReportError(p->package, SyntaxError, pos, "Only regular assignment may have multiple left or right values");
+                ReportError(p->package, SyntaxError, op.pos, "Only regular assignment may have multiple left or right values");
             }
-            rhs[0] = NewExprBinary(pkg, op, pos, exprs[0], rhs[0]);
+            rhs[0] = NewExprBinary(pkg, op, exprs[0], rhs[0]);
             return NewStmtAssign(pkg, start, exprs, rhs);
         }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -1180,7 +1180,7 @@ DynamicArray(Stmt *) parseStmtsUntilEof(Parser *p) {
 }
 
 void parsePackageCode(Package *pkg, const char *code) {
-    Lexer lexer = MakeLexer(code, pkg->path);
+    Lexer lexer = MakeLexer(code, pkg);
     Token tok = NextToken(&lexer);
     Parser parser = {lexer, .tok = tok, pkg};
     pkg->stmts = parseStmtsUntilEof(&parser);

--- a/src/parser.c
+++ b/src/parser.c
@@ -23,6 +23,46 @@ i32 PrecedenceForTokenKind[NUM_TOKEN_KINDS] = {
     [TK_Assign] = 0,
 };
 
+SourceRange rangeFromTokens(Token start, Token end) {
+    u32 endOffset = (u32) (end.end - start.start) + start.pos.offset;
+    SourceRange range = {
+        start.pos.name,
+        start.pos.offset, endOffset,
+        start.pos.line, start.pos.column
+    };
+    return range;
+}
+
+SourceRange rangeFromTokenToEndOffset(Token token, u32 endOffset) {
+    SourceRange range = {
+        token.pos.name,
+        token.pos.offset, endOffset,
+        token.pos.line, token.pos.column,
+    };
+    return range;
+}
+
+SourceRange rangeFromNodes(AstNode start, AstNode end) {
+    Stmt *s = (Stmt*) start;
+    Stmt *e = (Stmt*) end;
+    SourceRange range = {
+        s->pos.name,
+        s->pos.offset, e->pos.endOffset,
+        s->pos.line, s->pos.column,
+    };
+    return range;
+}
+
+SourceRange rangeFromTokenToEndOfNode(Token token, AstNode node) {
+    Stmt *stmt = (Stmt *) node;
+    SourceRange range = {
+        token.pos.name,
+        token.pos.offset, stmt->pos.endOffset,
+        token.pos.line, token.pos.column,
+    };
+    return range;
+}
+
 typedef struct Parser Parser;
 struct Parser {
     Lexer lexer;
@@ -39,8 +79,6 @@ struct Parser {
     p->prevStart = p->tok.pos; \
     p->prevEnd = p->lexer.pos; \
     p->tok = NextToken(&p->lexer)
-
-#define CurrentToken p->tok
 
 b32 isToken(Parser *p, TokenKind kind) {
     return p->tok.kind == kind;
@@ -151,50 +189,59 @@ Stmt *parseStmt(Parser *p);
 
 Expr *parseExprAtom(Parser *p) {
     Package *pkg = p->package;
+    Token start = p->tok;
+
     switch (p->tok.kind) {
         case TK_Ident: {
-            Expr *e = NewExprIdent(pkg, p->tok.pos, p->tok.val.ident);
+            SourceRange range = rangeFromTokens(start, start);
+            Expr *e = NewExprIdent(pkg, range, p->tok.val.ident);
             nextToken();
             if (p->tok.kind == TK_Dot) {  // package.Member
                 nextToken();
+                SourceRange range = rangeFromTokens(start, p->tok);
                 const char *ident = parseIdent(p);
-                return NewExprSelector(pkg, e, ident);
+                return NewExprSelector(pkg, range, e, ident);
             }
             return e;
         }
 
         case TK_Int: {
-            Expr *e = NewExprLitInt(pkg, p->tok.pos, p->tok.val.i);
+            SourceRange range = rangeFromTokens(start, start);
+            Expr *e = NewExprLitInt(pkg, range, p->tok.val.i);
             nextToken();
             return e;
         }
 
         case TK_Float: {
-            Expr *e = NewExprLitFloat(pkg, p->tok.pos, p->tok.val.f);
+            SourceRange range = rangeFromTokens(start, start);
+            Expr *e = NewExprLitFloat(pkg, range, p->tok.val.f);
             nextToken();
             return e;
         }
 
         case TK_String: {
-            Expr *e = NewExprLitString(pkg, p->tok.pos, p->tok.val.s);
+            SourceRange range = rangeFromTokens(start, start);
+            Expr *e = NewExprLitString(pkg, range, p->tok.val.s);
             nextToken();
             return e;
         }
 
         case TK_Lparen: {
-            Position start = p->tok.pos;
             nextToken();
             Expr *expr = parseExpr(p, false);
+            Token end = p->tok;
             expectToken(p, TK_Rparen);
-            return NewExprParen(pkg, expr, start);
+
+            SourceRange range = rangeFromTokens(start, end);
+            return NewExprParen(pkg, range, expr);
         }
 
         case TK_Lbrack: {
-            Position start = p->tok.pos;
             nextToken();
             if (matchToken(p, TK_Rbrack)) {
                 Expr *type = parseType(p);
-                return NewExprTypeSlice(pkg, start, type);
+                SourceRange range = rangeFromTokenToEndOfNode(start, type);
+                return NewExprTypeSlice(pkg, range, type);
             }
             Expr *length = NULL;
             if (!matchToken(p, TK_Ellipsis)) {
@@ -202,11 +249,11 @@ Expr *parseExprAtom(Parser *p) {
             }
             expectToken(p, TK_Rbrack);
             Expr *type = parseType(p);
-            return NewExprTypeArray(pkg, start, length, type);
+            SourceRange range = rangeFromTokenToEndOfNode(start, type);
+            return NewExprTypeArray(pkg, range, length, type);
         }
 
         case TK_Lbrace: {
-            Position start = p->tok.pos;
             nextToken();
 
             DynamicArray(Expr_KeyValue *) elements = NULL;
@@ -219,36 +266,40 @@ Expr *parseExprAtom(Parser *p) {
                 }
             }
 
+            SourceRange range = rangeFromTokens(start, p->tok);
             expectToken(p, TK_Rbrace);
-            return NewExprLitCompound(pkg, start, NULL, elements);
+            return NewExprLitCompound(pkg, range, NULL, elements);
         }
 
         case TK_Dollar: {
-            Position start = p->tok.pos;
             nextToken();
+            Token end = p->tok;
             const char *name = parseIdent(p);
-            return NewExprTypePolymorphic(pkg, start, name);
+            SourceRange range = rangeFromTokens(start, end);
+            return NewExprTypePolymorphic(pkg, range, name);
         }
 
         caseEllipsis: // For `case TK_Directive` for #cvargs
         case TK_Ellipsis: {
             u8 flags = 0;
             flags |= matchDirective(p, internCVargs) ? TypeVariadicFlag_CVargs : 0;
-            Position start = p->tok.pos;
             expectToken(p, TK_Ellipsis); // NOTE: We must expect here because we handle the case of having #cvargs prior
-            return NewExprTypeVariadic(pkg, start, parseType(p), flags);
+            Expr *type = parseType(p);
+            SourceRange range = rangeFromTokenToEndOfNode(start, type);
+            return NewExprTypeVariadic(pkg, range, type, flags);
         }
 
         case TK_Mul: {
-            Position start = p->tok.pos;
             nextToken();
             Expr *type = parseType(p);
-            return NewExprTypePointer(pkg, start, type);
+            SourceRange range = rangeFromTokenToEndOfNode(start, type);
+            return NewExprTypePointer(pkg, range, type);
         }
 
         case TK_Directive: {
             if (p->tok.val.ident == internLocation || p->tok.val.ident == internFile || p->tok.val.ident == internLine || p->tok.val.ident == internFunction) {
-                Expr *expr = NewExprLocationDirective(pkg, p->tok.pos, p->tok.val.ident);
+                SourceRange range = rangeFromTokens(start, start);
+                Expr *expr = NewExprLocationDirective(pkg, range, p->tok.val.ident);
                 nextToken();
                 return expr;
             } else if (p->tok.val.ident == internCVargs) {
@@ -263,7 +314,8 @@ Expr *parseExprAtom(Parser *p) {
             if (ident == Keyword_fn) {
                 return parseFunctionType(p);
             } else if (ident == Keyword_nil) {
-                Expr *expr = NewExprLitNil(pkg, p->tok.pos);
+                SourceRange range = rangeFromTokens(start, start);
+                Expr *expr = NewExprLitNil(pkg, range);
                 nextToken();
                 return expr;
             } else if (ident == Keyword_struct) {
@@ -282,24 +334,23 @@ Expr *parseExprAtom(Parser *p) {
         }
 
         caseCast: { // See `case TK_Keyword:`
-            Position start = p->tok.pos;
             nextToken();
             expectToken(p, TK_Lparen);
             Expr *type = parseType(p);
             expectToken(p, TK_Rparen);
             Expr *expr = parseExpr(p, false);
-            return NewExprCast(pkg, start, type, expr);
+            SourceRange range = rangeFromTokenToEndOfNode(start, expr);
+            return NewExprCast(pkg, range, type, expr);
         }
 
         caseAutocast: { // See `case TK_Keyword:`
-            Position start = p->tok.pos;
             nextToken();
             Expr *expr = parseExpr(p, false);
-            return NewExprAutocast(pkg, start, expr);
+            SourceRange range = rangeFromTokenToEndOfNode(start, expr);
+            return NewExprAutocast(pkg, range, expr);
         }
 
         caseStruct: { // See `case TK_Keyword:`
-            Position start = p->tok.pos;
             nextToken();
 
             // TODO(Brett, vdka): directives
@@ -314,7 +365,7 @@ Expr *parseExprAtom(Parser *p) {
             DynamicArray(AggregateItem) items = NULL;
 
             while (!isToken(p, TK_Rbrace)) {
-                Position start = p->tok.pos;
+                Token start = p->tok;
 
                 DynamicArray(const char *) names = parseIdentList(p);
 
@@ -322,7 +373,8 @@ Expr *parseExprAtom(Parser *p) {
 
                 Expr *type = parseType(p);
 
-                AggregateItem item = {.start = start, .names = names, .type = type};
+                SourceRange range = rangeFromTokenToEndOfNode(start, type);
+                AggregateItem item = {range, .names = names, .type = type};
                 ArrayPush(items, item);
 
                 if (isToken(p, TK_Rbrace)) {
@@ -333,13 +385,13 @@ Expr *parseExprAtom(Parser *p) {
                 if (isTokenEof(p)) break;
             }
 
+            SourceRange range = rangeFromTokens(start, p->tok);
             expectToken(p, TK_Rbrace);
 
-            return NewExprTypeStruct(pkg, start, items);
+            return NewExprTypeStruct(pkg, range, items);
         }
 
         caseUnion: { // See `case TK_Keyword:`
-            Position start = p->tok.pos;
             nextToken();
 
             // TODO(Brett, vdka): directives
@@ -349,15 +401,15 @@ Expr *parseExprAtom(Parser *p) {
             DynamicArray(AggregateItem) items = NULL;
 
             while (!isToken(p, TK_Rbrace)) {
-                Position start = p->tok.pos;
+                Token start = p->tok;
 
                 DynamicArray(const char *) names = parseIdentList(p);
 
                 expectToken(p, TK_Colon);
 
                 Expr *type = parseType(p);
-
-                AggregateItem item = {.start = start, .names = names, .type = type};
+                SourceRange range = rangeFromTokenToEndOfNode(start, type);
+                AggregateItem item = {range, .names = names, .type = type};
                 ArrayPush(items, item);
 
                 if (isToken(p, TK_Rbrace)) {
@@ -368,17 +420,16 @@ Expr *parseExprAtom(Parser *p) {
                 if (isTokenEof(p)) break;
             }
 
+            SourceRange range = rangeFromTokens(start, p->tok);
             expectToken(p, TK_Rbrace);
 
-            return NewExprTypeUnion(pkg, start, items);
+            return NewExprTypeUnion(pkg, range, items);
         }
 
         caseEnum: { // See `case TK_Keyword:`
-            Position start = p->tok.pos;
-            Expr *explicitType = NULL;
-
             nextToken();
 
+            Expr *explicitType = NULL;
             if (!isToken(p, TK_Lbrace) && !isToken(p, TK_Directive)) {
                 explicitType = parseType(p);
             }
@@ -387,7 +438,7 @@ Expr *parseExprAtom(Parser *p) {
 
             DynamicArray(EnumItem) items = NULL;
             while (!isToken(p, TK_Rbrace)) {
-                Position start = p->tok.pos;
+                Token start = p->tok;
                 const char *name = parseIdent(p);
                 Expr *init = NULL;
 
@@ -403,7 +454,8 @@ Expr *parseExprAtom(Parser *p) {
                     init = parseExpr(p, true);
                 }
 
-                EnumItem item = {.start = start, .name = name, .init = init};
+                SourceRange range = init ? rangeFromTokenToEndOfNode(start, init) : rangeFromTokens(start, start);
+                EnumItem item = {range, .name = name, .init = init};
                 ArrayPush(items, item);
 
                 if (isToken(p, TK_Rbrace)) {
@@ -414,103 +466,122 @@ Expr *parseExprAtom(Parser *p) {
                 if (isTokenEof(p)) break;
             }
 
+            SourceRange range = rangeFromTokens(start, p->tok);
             expectToken(p, TK_Rbrace);
 
-            return NewExprTypeEnum(pkg, start, explicitType, items);
+            return NewExprTypeEnum(pkg, range, explicitType, items);
         }
 
         default:
             ReportError(p->package, SyntaxError, p->tok.pos, "Unexpected token '%s'", DescribeToken(p->tok));
     }
 
-    Position start = p->tok.pos;
+    SourceRange range = rangeFromTokens(start, start);
     nextToken();
-    return NewExprInvalid(pkg, start);
+    return NewExprInvalid(pkg, range);
 }
 
 Expr *parseExprPrimary(Parser *p, b32 noCompoundLiteral) {
     Package *pkg = p->package;
+    Token start = p->tok;
     Expr *x = parseExprAtom(p);
     for (;;) {
         switch (p->tok.kind) {
-            case TK_Dot: {
+            case TK_Dot: { // Selector
                 nextToken();
-                x = NewExprSelector(pkg, x, parseIdent(p));
+                SourceRange range = rangeFromTokens(start, p->tok);
+                x = NewExprSelector(pkg, range, x, parseIdent(p));
                 continue;
             }
 
-            case TK_Lbrack: {
+            case TK_Lbrack: { // Slice | Subscript
                 nextToken();
                 if (matchToken(p, TK_Colon)) {
+                    Token end = p->tok;
                     if (matchToken(p, TK_Rbrack)) {
-                        x = NewExprSlice(pkg, x, NULL, NULL);
+                        SourceRange range = rangeFromTokens(start, end);
+                        x = NewExprSlice(pkg, range, x, NULL, NULL);
                         continue;
                     }
                     Expr *hi = parseExpr(p, noCompoundLiteral);
+                    end = p->tok;
                     expectToken(p, TK_Rbrack);
-                    x = NewExprSlice(pkg, x, NULL, hi);
+                    SourceRange range = rangeFromTokens(start, end);
+                    x = NewExprSlice(pkg, range, x, NULL, hi);
                     continue;
                 }
                 Expr *index = parseExpr(p, noCompoundLiteral);
                 if (matchToken(p, TK_Colon)) {
+                    Token end = p->tok;
                     if (matchToken(p, TK_Rbrack)) {
-                        x = NewExprSlice(pkg, x, index, NULL);
+                        SourceRange range = rangeFromTokens(start, end);
+                        x = NewExprSlice(pkg, range, x, index, NULL);
                         continue;
                     }
                     Expr *hi = parseExpr(p, noCompoundLiteral);
+                    end = p->tok;
                     expectToken(p, TK_Rbrack);
-                    x = NewExprSlice(pkg, x, index, hi);
+                    SourceRange range = rangeFromTokens(start, end);
+                    x = NewExprSlice(pkg, range, x, index, hi);
                     continue;
                 }
+                Token end = p->tok;
                 expectToken(p, TK_Rbrack);
-                x = NewExprSubscript(pkg, x, index);
+                SourceRange range = rangeFromTokens(start, end);
+                x = NewExprSubscript(pkg, range, x, index);
                 continue;
             }
 
-            case TK_Lparen: {
+            case TK_Lparen: { // Call Expr
                 nextToken();
                 DynamicArray(Expr_KeyValue *) args = NULL;
                 if (!isToken(p, TK_Rparen)) {
+                    Token start = p->tok;
+
                     Expr_KeyValue *arg = AllocAst(pkg, sizeof(Expr_KeyValue));
-                    arg->start = p->tok.pos;
                     arg->value = parseExpr(p, noCompoundLiteral);
                     if (isToken(p, TK_Colon) && arg->value->kind == ExprKind_Ident) {
                         arg->key = arg->value;
                         arg->value = parseExpr(p, noCompoundLiteral);
                     }
+                    arg->pos = rangeFromTokenToEndOfNode(start, arg->value);
                     ArrayPush(args, arg);
                     while (matchToken(p, TK_Comma)) {
                         if (isToken(p, TK_Rparen)) break; // Allow trailing comma in argument list
+                        start = p->tok;
 
                         arg = AllocAst(pkg, sizeof(Expr_KeyValue));
-                        arg->start = p->tok.pos;
                         arg->value = parseExpr(p, noCompoundLiteral);
                         if (isToken(p, TK_Colon) && arg->value->kind == ExprKind_Ident) {
                             arg->key = arg->value;
                             arg->value = parseExpr(p, noCompoundLiteral);
                         }
+                        arg->pos = rangeFromTokenToEndOfNode(start, arg->value);
                         ArrayPush(args, arg);
                     }
                 }
+                SourceRange range = rangeFromTokens(start, p->tok);
                 expectToken(p, TK_Rparen);
-                x = NewExprCall(pkg, x, args);
+                x = NewExprCall(pkg, range, x, args);
                 continue;
             }
 
             case TK_Lbrace: {
                 if (x->kind == ExprKind_TypeFunction) {
-                    Position startOfBlock = p->tok.pos;
+                    Token startOfBlock = p->tok;
                     nextToken();
                     DynamicArray(Stmt *) stmts = NULL;
                     while (isNotRbraceOrEOF(p)) {
                         ArrayPush(stmts, parseStmt(p));
                         matchToken(p, TK_Terminator);
                     }
+                    SourceRange blockRange = rangeFromTokens(startOfBlock, p->tok);
+                    SourceRange functionRange = rangeFromTokens(start, p->tok);
                     expectToken(p, TK_Rbrace);
                     Stmt_Block *block = AllocAst(p->package, sizeof(Stmt_Block));
-                    block->start = startOfBlock;
+                    block->pos = blockRange;
                     block->stmts = stmts;
-                    x = NewExprLitFunction(pkg, x, block, 0);
+                    x = NewExprLitFunction(pkg, functionRange, x, block, 0);
                     continue;
                 }
                 if (noCompoundLiteral) return x;
@@ -527,8 +598,9 @@ Expr *parseExprPrimary(Parser *p, b32 noCompoundLiteral) {
                         matchToken(p, TK_Terminator);
                     }
                 }
+                SourceRange range = rangeFromTokens(start, p->tok);
                 expectToken(p, TK_Rbrace);
-                x = NewExprLitCompound(pkg, x->start, x, elements);
+                x = NewExprLitCompound(pkg, range, x, elements);
                 continue;
             }
 
@@ -539,14 +611,19 @@ Expr *parseExprPrimary(Parser *p, b32 noCompoundLiteral) {
 }
 
 Expr *parseExprUnary(Parser *p, b32 noCompoundLiteral) {
+    Token start = p->tok;
     if (matchToken(p, TK_Mul)) {
-        return NewExprTypePointer(p->package, p->prevStart, parseType(p));
+        Expr *type = parseType(p);
+        SourceRange range = rangeFromTokenToEndOfNode(start, type);
+        return NewExprTypePointer(p->package, range, type);
     }
     switch (p->tok.kind) {
         case TK_Add: case TK_Sub: case TK_Not: case TK_BNot: case TK_Xor: case TK_And: case TK_Lss: {
             TokenKind op = p->tok.kind;
             nextToken();
-            return NewExprUnary(p->package, p->prevStart, op, parseExprUnary(p, noCompoundLiteral));
+            Expr *expr = parseExprUnary(p, noCompoundLiteral);
+            SourceRange range = rangeFromTokenToEndOfNode(start, expr);
+            return NewExprUnary(p->package, range, op, expr);
         }
         default:
             return parseExprPrimary(p, noCompoundLiteral);
@@ -568,10 +645,12 @@ Expr *parseExprBinary(Parser *p, i32 prec1, b32 noCompoundLiteral) {
             }
             expectToken(p, TK_Colon);
             Expr *fail = parseExpr(p, noCompoundLiteral);
-            return NewExprTernary(p->package, lhs, pass, fail);
+            SourceRange range = rangeFromNodes(lhs, fail);
+            return NewExprTernary(p->package, range, lhs, pass, fail);
         }
         Expr *rhs = parseExprBinary(p, precedence + 1, noCompoundLiteral);
-        lhs = NewExprBinary(p->package, op, lhs, rhs);
+        SourceRange range = rangeFromNodes(lhs, rhs);
+        lhs = NewExprBinary(p->package, range, op, lhs, rhs);
     }
 }
 
@@ -580,14 +659,15 @@ Expr *parseExpr(Parser *p, b32 noCompoundLiteral) {
 }
 
 Expr_KeyValue *parseExprCompoundField(Parser *p) {
+    Token start = p->tok;
     Expr_KeyValue *field = AllocAst(p->package, sizeof(Expr_KeyValue));
-    field->start = p->tok.pos;
     if (matchToken(p, TK_Lbrack)) {
         field->flags = KeyValueFlag_Index;
         field->key = parseExpr(p, false);
         expectToken(p, TK_Rbrack);
         expectToken(p, TK_Colon);
         field->value = parseExpr(p, false);
+        field->pos = rangeFromTokenToEndOfNode(start, field->value);
         return field;
     } else {
         field->value = parseExpr(p, false);
@@ -597,8 +677,8 @@ Expr_KeyValue *parseExprCompoundField(Parser *p) {
                 ReportError(p->package, SyntaxError, p->prevStart, "Named initializer value must be an identifier or surrounded in '[]'");
             }
             field->value = parseExpr(p, false);
-            return field;
         }
+        field->pos = rangeFromTokenToEndOfNode(start, field->value);
         return field;
     }
 }
@@ -626,7 +706,7 @@ void parseFunctionParameters(u32 *nVarargs, b32 *namedParameters, Parser *p, Dyn
                     continue;
                 }
                 Expr_KeyValue *kv = AllocAst(p->package, sizeof(Expr_KeyValue));
-                kv->start = exprs[i]->start;
+                kv->pos = exprs[i]->pos;
                 kv->key = exprs[i];
                 kv->value = type;
                 ArrayPush(*params, kv);
@@ -659,15 +739,17 @@ void parseFunctionParameters(u32 *nVarargs, b32 *namedParameters, Parser *p, Dyn
 }
 
 Expr *parseFunctionType(Parser *p) {
-    Position start = p->tok.pos;
+    Token start = p->tok;
     nextToken();
     DynamicArray(Expr_KeyValue *) params = NULL;
     u32 nVarargs;
     b32 namedParameters;
     parseFunctionParameters(&nVarargs, &namedParameters, p, &params);
     expectToken(p, TK_RetArrow);
+
+    SourceRange range;
     DynamicArray(Expr *) results = NULL;
-    if (matchToken(p, TK_Lparen)) {
+    if (matchToken(p, TK_Lparen)) { // We need to handle labels in the result list eg. `(Node, ok: bool)`
         nVarargs = 0;
         namedParameters = false;
         do {
@@ -698,14 +780,17 @@ Expr *parseFunctionType(Parser *p) {
                 }
             }
         } while (matchToken(p, TK_Comma));
+        range = rangeFromTokens(start, p->tok);
         expectToken(p, TK_Rparen);
-    } else {
+    } else { // Result list cannot have labels
         ArrayPush(results, parseType(p));
         while (matchToken(p, TK_Comma)) {
             ArrayPush(results, parseType(p));
         }
+        Expr *last = results[ArrayLen(results) - 1];
+        range = rangeFromTokenToEndOfNode(start, last);
     }
-    return NewExprTypeFunction(p->package, start, params, results);
+    return NewExprTypeFunction(p->package, range, params, results);
 }
 
 DynamicArray(Expr *) parseExprList(Parser *p, b32 noCompoundLiteral) {
@@ -718,16 +803,18 @@ DynamicArray(Expr *) parseExprList(Parser *p, b32 noCompoundLiteral) {
 }
 
 Stmt_Block *parseBlock(Parser *p) {
-    Position start = p->tok.pos;
+    Token start = p->tok;
     expectToken(p, TK_Lbrace);
     DynamicArray(Stmt *) stmts = NULL;
     while (isNotRbraceOrEOF(p)) {
         ArrayPush(stmts, parseStmt(p));
     }
+
+    SourceRange range = rangeFromTokens(start, p->tok);
     expectToken(p, TK_Rbrace);
     matchToken(p, TK_Terminator); // consume terminator if needed `if a {} else {}
     Stmt_Block *block = AllocAst(p->package, sizeof(Stmt_Block));
-    block->start = start;
+    block->pos = range;
     block->stmts = stmts;
     return block;
 }
@@ -735,14 +822,16 @@ Stmt_Block *parseBlock(Parser *p) {
 // isIdentList being non NULL indicates that an ident list is permitted (for ... in)
 Stmt *parseSimpleStmt(Parser *p, b32 noCompoundLiteral, b32 *isIdentList) {
     Package *pkg = p->package;
-    Position start = p->tok.pos;
+    Token start = p->tok;
 
     DynamicArray(Expr *) exprs = parseExprList(p, noCompoundLiteral);
     switch (p->tok.kind) {
         case TK_Assign: {
             nextToken();
             DynamicArray(Expr *) rhs = parseExprList(p, noCompoundLiteral);
-            return NewStmtAssign(pkg, start, exprs, rhs);
+            Expr *last = rhs[ArrayLen(rhs) - 1];
+            SourceRange range = rangeFromTokenToEndOfNode(start, last);
+            return NewStmtAssign(pkg, range, exprs, rhs);
         }
 
         case TK_AddAssign: case TK_SubAssign: case TK_MulAssign: case TK_DivAssign:
@@ -755,14 +844,17 @@ Stmt *parseSimpleStmt(Parser *p, b32 noCompoundLiteral, b32 *isIdentList) {
             if (ArrayLen(rhs) > 1) {
                 ReportError(p->package, SyntaxError, op.pos, "Only regular assignment may have multiple left or right values");
             }
-            rhs[0] = NewExprBinary(pkg, op, exprs[0], rhs[0]);
-            return NewStmtAssign(pkg, start, exprs, rhs);
+            SourceRange range = rangeFromNodes(exprs[0], rhs[0]);
+            rhs[0] = NewExprBinary(pkg, range, op, exprs[0], rhs[0]);
+            return NewStmtAssign(pkg, range, exprs, rhs);
         }
 
         case TK_Colon: {
+            Token colon = p->tok;
             nextToken();
             if (ArrayLen(exprs) == 1 && exprs[0]->kind == ExprKind_Ident && (matchToken(p, TK_Terminator) || isTokenEof(p))) {
-                return NewStmtLabel(pkg, start, exprs[0]->Ident.name);
+                SourceRange range = rangeFromTokens(start, colon);
+                return NewStmtLabel(pkg, range, exprs[0]->Ident.name);
             }
 
             DynamicArray(Expr_Ident *) idents = NULL;
@@ -779,26 +871,31 @@ Stmt *parseSimpleStmt(Parser *p, b32 noCompoundLiteral, b32 *isIdentList) {
 
             if (matchToken(p, TK_Assign)) {
                 rhs = parseExprList(p, noCompoundLiteral);
-                return (Stmt *) NewDeclVariable(pkg, start, idents, NULL, rhs);
+                SourceRange range = rangeFromNodes(exprs[0], rhs[ArrayLen(rhs) - 1]);
+                return (Stmt *) NewDeclVariable(pkg, range, idents, NULL, rhs);
             } 
             
             if (matchToken(p, TK_Colon)) {
                 rhs = parseExprList(p, noCompoundLiteral);
-                return (Stmt *) NewDeclConstant(pkg, start, idents, NULL, rhs);
+                SourceRange range = rangeFromNodes(exprs[0], rhs[ArrayLen(rhs) - 1]);
+                return (Stmt *) NewDeclConstant(pkg, range, idents, NULL, rhs);
             }
 
             Expr *type = parseExpr(p, noCompoundLiteral);
             if (matchToken(p, TK_Assign)) {
                 rhs = parseExprList(p, noCompoundLiteral);
-                return (Stmt *) NewDeclVariable(pkg, start, idents, type, rhs);
+                SourceRange range = rangeFromNodes(exprs[0], rhs[ArrayLen(rhs) - 1]);
+                return (Stmt *) NewDeclVariable(pkg, range, idents, type, rhs);
             } 
             
             if (matchToken(p, TK_Colon)) {
                 rhs = parseExprList(p, noCompoundLiteral);
-                return (Stmt *) NewDeclConstant(pkg, start, idents, type, rhs);
+                SourceRange range = rangeFromNodes(exprs[0], rhs[ArrayLen(rhs) - 1]);
+                return (Stmt *) NewDeclConstant(pkg, range, idents, type, rhs);
             }
 
-            return (Stmt *) NewDeclVariable(pkg, start, idents, type, NULL);
+            SourceRange range = rangeFromNodes(exprs[0], type);
+            return (Stmt *) NewDeclVariable(pkg, range, idents, type, NULL);
         }
 
         default:
@@ -823,9 +920,14 @@ Stmt *parseSimpleStmt(Parser *p, b32 noCompoundLiteral, b32 *isIdentList) {
     return (Stmt *) exprs[0];
 }
 
-Stmt *parseStmtFor(Parser *p, Package *pkg, Position start) {
+Stmt *parseStmtFor(Parser *p, Package *pkg) {
+    ASSERT(p->tok.val.s == Keyword_for);
+    Token start = p->tok;
+    nextToken();
     if (isToken(p, TK_Lbrace)) {
-        return NewStmtFor(pkg, start, NULL, NULL, NULL, parseBlock(p));
+        Stmt_Block *body = parseBlock(p);
+        SourceRange range = rangeFromTokenToEndOffset(start, body->pos.endOffset);
+        return NewStmtFor(pkg, range, NULL, NULL, NULL, body);
     }
     Stmt *s1, *s2, *s3;
     s1 = s2 = s3 = NULL;
@@ -846,7 +948,8 @@ Stmt *parseStmtFor(Parser *p, Package *pkg, Position start) {
                 }
                 aggregate = parseExpr(p, true);
                 Stmt_Block *body = parseBlock(p);
-                return NewStmtForIn(pkg, start, valueName, indexName, aggregate, body);
+                SourceRange range = rangeFromTokenToEndOffset(start, body->pos.endOffset);
+                return NewStmtForIn(pkg, range, valueName, indexName, aggregate, body);
             } else {
                 ReportError(p->package, SyntaxError, p->tok.pos, "Expected single expression or 'in' for iterator");
             }
@@ -868,10 +971,15 @@ Stmt *parseStmtFor(Parser *p, Package *pkg, Position start) {
     }
 
     Stmt_Block *body = parseBlock(p);
-    return NewStmtFor(pkg, start, s1, (Expr *) s2, s3, body);
+    SourceRange range = rangeFromTokenToEndOffset(start, body->pos.endOffset);
+    return NewStmtFor(pkg, range, s1, (Expr *) s2, s3, body);
 }
 
-Stmt *parseStmtSwitch(Parser *p, Package *pkg, Position start) {
+Stmt *parseStmtSwitch(Parser *p, Package *pkg) {
+    ASSERT(p->tok.val.s == Keyword_switch);
+    Token start = p->tok;
+    nextToken();
+
     Expr *match = NULL;
     if (!isToken(p, TK_Lbrace)) match = parseExpr(p, true);
     expectToken(p, TK_Lbrace);
@@ -879,10 +987,12 @@ Stmt *parseStmtSwitch(Parser *p, Package *pkg, Position start) {
     for (;;) {
         if (!matchKeyword(p, Keyword_case)) break;
 
-        Position caseStart = p->tok.pos;
+        Token caseStart = p->tok;
+        Token bodyStart = p->tok;
         DynamicArray(Expr *) exprs = NULL;
         if (!matchToken(p, TK_Colon)) {
             exprs = parseExprList(p, true);
+            bodyStart = p->tok;
             expectToken(p, TK_Colon);
         }
 
@@ -892,15 +1002,21 @@ Stmt *parseStmtSwitch(Parser *p, Package *pkg, Position start) {
             ArrayPush(stmts, stmt);
         }
         Stmt_Block *block = AllocAst(pkg, sizeof(Stmt_Block));
-        block->start = caseStart;
+        if (stmts) {
+            block->pos = rangeFromTokenToEndOfNode(bodyStart, stmts[ArrayLen(stmts) - 1]);
+        } else {
+            block->pos = rangeFromTokenToEndOffset(bodyStart, p->tok.pos.offset); // from the ':' to w/e is next
+        }
         block->stmts = stmts;
-        Stmt *scase = NewStmtSwitchCase(pkg, caseStart, exprs, block);
+        SourceRange range = rangeFromTokenToEndOffset(caseStart, block->pos.endOffset);
+        Stmt *scase = NewStmtSwitchCase(pkg, range, exprs, block);
         ArrayPush(cases, scase);
     }
 
+    SourceRange range = rangeFromTokens(start, p->tok);
     expectToken(p, TK_Rbrace);
 
-    return NewStmtSwitch(pkg, start, match, cases);
+    return NewStmtSwitch(pkg, range, match, cases);
 }
 
 void parsePrefixDirectives(Parser *p) {
@@ -928,12 +1044,15 @@ void parsePrefixDirectives(Parser *p) {
 typedef struct SuffixDirectives SuffixDirectives;
 struct SuffixDirectives {
     const char *linkname;
+    SourceRange pos;
 };
 
 SuffixDirectives parseSuffixDirectives(Parser *p) {
     SuffixDirectives val = {0};
+    Token start = p->tok;
+    Token end = start;
     while (isSuffixDirective(p) && !isTokenEof(p)) {
-        Position start = p->tok.pos;
+        end = p->tok;
         if (p->tok.val.ident == internLinkName) {
             nextToken();
             const char *name = p->tok.val.s;
@@ -947,10 +1066,11 @@ SuffixDirectives parseSuffixDirectives(Parser *p) {
             UNIMPLEMENTED();
         }
     }
+    val.pos = rangeFromTokens(start, end);
     return val;
 }
 
-Decl *parseForeignDecl(Parser *p, Position start, Expr *library) {
+Decl *parseForeignDecl(Parser *p, Token start, Expr *library) {
     const char *name = parseIdent(p);
 
     bool isConstant = false;
@@ -977,17 +1097,18 @@ Decl *parseForeignDecl(Parser *p, Position start, Expr *library) {
         linkname = name;
     }
 
-    return NewDeclForeign(p->package, start, library, isConstant, name, type, linkname, p->callingConvention);
+    SourceRange range = rangeFromTokenToEndOffset(start, suffixDirectives.pos.endOffset);
+    return NewDeclForeign(p->package, range, library, isConstant, name, type, linkname, p->callingConvention);
 }
 
-Decl *parseForeignDeclBlock(Parser *p, Position start, Expr *library) {
+Decl *parseForeignDeclBlock(Parser *p, Token start, Expr *library) {
 
     DynamicArray(char) tempStringBuffer = NULL;
     DynamicArray(Decl_ForeignBlockMember) members = NULL;
 
     while (!isToken(p, TK_Rbrace) && !isTokenEof(p)) {
 
-        Position start = p->tok.pos;
+        Token start = p->tok;
         const char *name = parseIdent(p);
 
         bool isConstant = false;
@@ -997,6 +1118,7 @@ Decl *parseForeignDeclBlock(Parser *p, Position start, Expr *library) {
         }
         Expr *type = parseType(p);
 
+        // FIXME: @position If there is no suffix directive then the end used from this is the start of the next token
         SuffixDirectives suffixDirectives = parseSuffixDirectives(p);
 
         const char *linkname;
@@ -1015,18 +1137,20 @@ Decl *parseForeignDeclBlock(Parser *p, Position start, Expr *library) {
 
         expectTerminator(p);
 
-        Decl_ForeignBlockMember member = {start, name, isConstant, type, linkname};
+        SourceRange range = rangeFromTokenToEndOffset(start, suffixDirectives.pos.endOffset);
+        Decl_ForeignBlockMember member = {range, name, isConstant, type, linkname};
         ArrayPush(members, member);
     }
 
+    SourceRange range = rangeFromTokens(start, p->tok);
     expectToken(p, TK_Rbrace);
 
-    return NewDeclForeignBlock(p->package, start, library, p->callingConvention, members);
+    return NewDeclForeignBlock(p->package, range, library, p->callingConvention, members);
 }
 
 Stmt *parseStmt(Parser *p) {
     Package *pkg = p->package;
-    Position start = p->tok.pos;
+    Token start = p->tok;
 
     switch (p->tok.kind) {
         exprStart:
@@ -1040,8 +1164,8 @@ Stmt *parseStmt(Parser *p) {
         }
 
         case TK_Lbrace: {
-            Stmt_Block *block = parseBlock(p);
-            return NewStmtBlock(pkg, block->start, block->stmts);
+            Stmt_Block *block = parseBlock(p); // FIXME: @extra_alloc
+            return NewStmtBlock(pkg, block->pos, block->stmts);
         }
 
         case TK_Directive: {
@@ -1058,7 +1182,7 @@ Stmt *parseStmt(Parser *p) {
                 // #foreign glfw #callconv "c" #linkprefix "glfw"
                 nextToken();
                 Expr *library = parseExpr(p, false);
-                matchToken(p, TK_Terminator);
+                matchToken(p, TK_Terminator); // FIXME: Allow only @newlines_only
 
                 // This will update the parser state, setting callingConvention and linkPrefix
                 parsePrefixDirectives(p);
@@ -1086,12 +1210,14 @@ Stmt *parseStmt(Parser *p) {
             if (isDirective(p, internImport)) {
                 nextToken();
                 Expr *path = parseExpr(p, false);
+                SourceRange range = rangeFromTokenToEndOfNode(start, path);
                 const char *alias = NULL;
                 if (isToken(p, TK_Ident)) {
+                    range = rangeFromTokens(start, p->tok);
                     alias = parseIdent(p);
                 }
                 expectTerminator(p);
-                return (Stmt *) NewDeclImport(pkg, start, path, alias);
+                return (Stmt *) NewDeclImport(pkg, range, path, alias);
             }
 
             return NULL;
@@ -1131,8 +1257,8 @@ Stmt *parseStmt(Parser *p) {
                 Expr *target = parseExpr(p, true);
                 return NewStmtGoto(pkg, start, keyword, target);
             }
-            if (matchKeyword(p, Keyword_for)) {
-                return parseStmtFor(p, pkg, start);
+            if (isKeyword(p, Keyword_for)) {
+                return parseStmtFor(p, pkg);
             }
             if (matchKeyword(p, Keyword_return)) {
                 DynamicArray(Expr *) exprs = NULL;
@@ -1142,8 +1268,8 @@ Stmt *parseStmt(Parser *p) {
                 if (p->tok.kind != TK_Rbrace) expectTerminator(p);
                 return NewStmtReturn(pkg, start, exprs);
             }
-            if (matchKeyword(p, Keyword_switch)) {
-                return parseStmtSwitch(p, pkg, start);
+            if (isKeyword(p, Keyword_switch)) {
+                return parseStmtSwitch(p, pkg);
             }
             if (matchKeyword(p, Keyword_using)) UNIMPLEMENTED();
 


### PR DESCRIPTION
The compiler will now highlight in the source code any errors, it has a flag to do this with / without color. Each AST node now stores a range instead of just a singe character position.

## Still TODO
Prior to parsing source code into an AST we report errors for singular positions still. This needs to be united so that errors emitted in the parser regarding tokens can be emitted with source code.